### PR TITLE
Added MenuItemReview Placeholder pages and tests

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -11,6 +11,10 @@ import RestaurantIndexPage from "main/pages/Restaurants/RestaurantIndexPage";
 import RestaurantCreatePage from "main/pages/Restaurants/RestaurantCreatePage";
 import RestaurantEditPage from "main/pages/Restaurants/RestaurantEditPage";
 
+import MenuItemReviewIndexPage from "main/pages/MenuItemReviews/MenuItemReviewIndexPage";
+import MenuItemReviewCreatePage from "main/pages/MenuItemReviews/MenuItemReviewCreatePage";
+import MenuItemReviewEditPage from "main/pages/MenuItemReviews/MenuItemReviewEditPage";
+
 import PlaceholderIndexPage from "main/pages/Placeholder/PlaceholderIndexPage";
 import PlaceholderCreatePage from "main/pages/Placeholder/PlaceholderCreatePage";
 import PlaceholderEditPage from "main/pages/Placeholder/PlaceholderEditPage";
@@ -84,6 +88,29 @@ function App() {
             exact
             path="/placeholder/create"
             element={<PlaceholderCreatePage />}
+          />
+        </>
+      )}
+      {hasRole(currentUser, "ROLE_USER") && (
+        <>
+          <Route
+            exact
+            path="/menuitemreviews"
+            element={<MenuItemReviewIndexPage />}
+          />
+        </>
+      )}
+      {hasRole(currentUser, "ROLE_ADMIN") && (
+        <>
+          <Route
+            exact
+            path="/menuitemreviews/edit/:id"
+            element={<MenuItemReviewEditPage />}
+          />
+          <Route
+            exact
+            path="/menuitemreviews/create"
+            element={<MenuItemReviewCreatePage />}
           />
         </>
       )}

--- a/frontend/src/main/components/Nav/AppNavbar.jsx
+++ b/frontend/src/main/components/Nav/AppNavbar.jsx
@@ -48,7 +48,6 @@ export default function AppNavbar({
           <>
             {/* be sure that each NavDropdown has a unique id and data-testid  */}
           </>
-
           <Navbar.Collapse className="justify-content-between">
             <Nav className="mr-auto">
               {hasRole(currentUser, "ROLE_ADMIN") && (
@@ -70,6 +69,9 @@ export default function AppNavbar({
                   </Nav.Link>
                   <Nav.Link as={Link} to="/placeholder">
                     Placeholder
+                  </Nav.Link>
+                  <Nav.Link as={Link} to="/menuitemreviews">
+                    MenuItemReviews
                   </Nav.Link>
                 </>
               ) : (

--- a/frontend/src/main/pages/MenuItemReviews/MenuItemReviewCreatePage.jsx
+++ b/frontend/src/main/pages/MenuItemReviews/MenuItemReviewCreatePage.jsx
@@ -1,0 +1,12 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function MenuItemReviewCreatePage() {
+  // Stryker disable all : placeholder for future implementation
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Create page not yet implemented</h1>
+      </div>
+    </BasicLayout>
+  );
+}

--- a/frontend/src/main/pages/MenuItemReviews/MenuItemReviewEditPage.jsx
+++ b/frontend/src/main/pages/MenuItemReviews/MenuItemReviewEditPage.jsx
@@ -1,0 +1,12 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function MenuItemReviewEditPage() {
+  // Stryker disable all : placeholder for future implementation
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Edit page not yet implemented</h1>
+      </div>
+    </BasicLayout>
+  );
+}

--- a/frontend/src/main/pages/MenuItemReviews/MenuItemReviewIndexPage.jsx
+++ b/frontend/src/main/pages/MenuItemReviews/MenuItemReviewIndexPage.jsx
@@ -1,0 +1,18 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function MenuItemReviewIndexPage() {
+  // Stryker disable all : placeholder for future implementation
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Index page not yet implemented</h1>
+        <p>
+          <a href="/menuitemreviews/create">Create</a>
+        </p>
+        <p>
+          <a href="/menuitemreviews/edit/1">Edit</a>
+        </p>
+      </div>
+    </BasicLayout>
+  );
+}

--- a/frontend/src/tests/pages/MenuItemReviews/MenuItemReviewCreatePage.test.jsx
+++ b/frontend/src/tests/pages/MenuItemReviews/MenuItemReviewCreatePage.test.jsx
@@ -1,0 +1,48 @@
+import { render, screen } from "@testing-library/react";
+import MenuItemReviewCreatePage from "main/pages/MenuItemReviews/MenuItemReviewCreatePage";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+import { expect } from "vitest";
+
+describe("MenuItemReviewCreatePage tests", () => {
+  const axiosMock = new AxiosMockAdapter(axios);
+
+  const setupUserOnly = () => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.userOnly);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  };
+
+  const queryClient = new QueryClient();
+  test("Renders expected content", async () => {
+    // arrange
+
+    setupUserOnly();
+
+    // act
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <MenuItemReviewCreatePage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    // assert
+
+    await screen.findByText("Create page not yet implemented");
+    expect(
+      screen.getByText("Create page not yet implemented"),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/tests/pages/MenuItemReviews/MenuItemReviewEditPage.test.jsx
+++ b/frontend/src/tests/pages/MenuItemReviews/MenuItemReviewEditPage.test.jsx
@@ -1,0 +1,47 @@
+import { render, screen } from "@testing-library/react";
+import MenuItemReviewEditPage from "main/pages/MenuItemReviews/MenuItemReviewEditPage";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+import { expect } from "vitest";
+
+describe("MenuItemReviewEditPage tests", () => {
+  const axiosMock = new AxiosMockAdapter(axios);
+
+  const setupUserOnly = () => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.userOnly);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  };
+
+  const queryClient = new QueryClient();
+  test("Renders expected content", async () => {
+    // arrange
+
+    setupUserOnly();
+
+    // act
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <MenuItemReviewEditPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    // assert
+    await screen.findByText("Edit page not yet implemented");
+    expect(
+      screen.getByText("Edit page not yet implemented"),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/tests/pages/MenuItemReviews/MenuItemReviewIndexPage.test.jsx
+++ b/frontend/src/tests/pages/MenuItemReviews/MenuItemReviewIndexPage.test.jsx
@@ -1,0 +1,50 @@
+import { render, screen } from "@testing-library/react";
+import MenuItemReviewIndexPage from "main/pages/MenuItemReviews/MenuItemReviewIndexPage";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+describe("MenuItemReviewIndexPage tests", () => {
+  const axiosMock = new AxiosMockAdapter(axios);
+
+  const setupUserOnly = () => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.userOnly);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  };
+
+  const queryClient = new QueryClient();
+  test("Renders expected content", async () => {
+    // arrange
+
+    setupUserOnly();
+
+    // act
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <MenuItemReviewIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await screen.findByText("Index page not yet implemented");
+
+    // assert
+    expect(
+      screen.getByText("Index page not yet implemented"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Create")).toBeInTheDocument();
+    expect(screen.getByText("Edit")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Closes #33.

In this PR, we add placeholder pages for Index, Create, and Edit pages for the menuItemReviews table.

You can see the pages with this dokku instance after you log in: https://team02-elissaalawi-dev.dokku-05.cs.ucsb.edu/

Screenshots: 

<img width="1911" height="1044" alt="Index" src="https://github.com/user-attachments/assets/83388d24-dec7-443d-a3c7-11de8897679d" />


<img width="1910" height="1030" alt="Edit" src="https://github.com/user-attachments/assets/33c91b60-28d0-4179-822f-64a26c0b776c" />

<img width="1912" height="1034" alt="Create" src="https://github.com/user-attachments/assets/9f0d2cba-f0c8-46a0-a491-b3225d163ff6" />

