### PR TITLE
ea - add MenuItemReview Index page with stories and tests

### DIFF
--- a/frontend/src/main/pages/MenuItemReviews/MenuItemReviewIndexPage.jsx
+++ b/frontend/src/main/pages/MenuItemReviews/MenuItemReviewIndexPage.jsx
@@ -1,17 +1,49 @@
+import React from "react";
+import { useBackend } from "main/utils/useBackend";
+
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import MenuItemReviewTable from "main/components/MenuItemReviews/MenuItemReviewTable";
+import { useCurrentUser, hasRole } from "main/utils/useCurrentUser";
+import { Button } from "react-bootstrap";
 
 export default function MenuItemReviewIndexPage() {
-  // Stryker disable all : placeholder for future implementation
+  const currentUser = useCurrentUser();
+
+  const {
+    data: menuItemReviews,
+    error: _error,
+    status: _status,
+  } = useBackend(
+    // Stryker disable next-line all : don't test internal caching of React Query
+    ["/api/menuitemreview/all"],
+    { method: "GET", url: "/api/menuitemreview/all" },
+    // Stryker disable next-line all : don't test default value of empty list
+    [],
+  );
+
+  const createButton = () => {
+    if (hasRole(currentUser, "ROLE_ADMIN")) {
+      return (
+        <Button
+          variant="primary"
+          href="/menuitemreviews/create"
+          style={{ float: "right" }}
+        >
+          Create MenuItemReview
+        </Button>
+      );
+    }
+  };
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Index page not yet implemented</h1>
-        <p>
-          <a href="/menuitemreviews/create">Create</a>
-        </p>
-        <p>
-          <a href="/menuitemreviews/edit/1">Edit</a>
-        </p>
+        {createButton()}
+        <h1>MenuItemReview</h1>
+        <MenuItemReviewTable
+          menuItemReviews={menuItemReviews}
+          currentUser={currentUser}
+        />
       </div>
     </BasicLayout>
   );

--- a/frontend/src/stories/pages/MenuItemReviews/MenuItemReviewIndexPage.stories.jsx
+++ b/frontend/src/stories/pages/MenuItemReviews/MenuItemReviewIndexPage.stories.jsx
@@ -1,0 +1,71 @@
+import React from "react";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { menuItemReviewFixtures } from "fixtures/menuItemReviewFixtures";
+import { http, HttpResponse } from "msw";
+
+import MenuItemReviewIndexPage from "main/pages/MenuItemReviews/MenuItemReviewIndexPage";
+
+export default {
+  title: "pages/MenuItemReviews/MenuItemReviewIndexPage",
+  component: MenuItemReviewIndexPage,
+};
+
+const Template = () => <MenuItemReviewIndexPage storybook={true} />;
+
+export const Empty = Template.bind({});
+Empty.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
+        status: 200,
+      });
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither, {
+        status: 200,
+      });
+    }),
+    http.get("/api/menuitemreview/all", () => {
+      return HttpResponse.json([], { status: 200 });
+    }),
+  ],
+};
+
+export const ThreeItemsOrdinaryUser = Template.bind({});
+
+ThreeItemsOrdinaryUser.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly);
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither);
+    }),
+    http.get("/api/menuitemreview/all", () => {
+      return HttpResponse.json(menuItemReviewFixtures.threeReviews);
+    }),
+  ],
+};
+
+export const ThreeItemsAdminUser = Template.bind({});
+
+ThreeItemsAdminUser.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.adminUser);
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither);
+    }),
+    http.get("/api/menuitemreview/all", () => {
+      return HttpResponse.json(menuItemReviewFixtures.threeReviews);
+    }),
+    http.delete("/api/menuItemReviews", () => {
+      return HttpResponse.json(
+        { message: "MenuItemReview deleted successfully" },
+        { status: 200 },
+      );
+    }),
+  ],
+};

--- a/frontend/src/tests/pages/MenuItemReviews/MenuItemReviewIndexPage.test.jsx
+++ b/frontend/src/tests/pages/MenuItemReviews/MenuItemReviewIndexPage.test.jsx
@@ -1,15 +1,28 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import MenuItemReviewIndexPage from "main/pages/MenuItemReviews/MenuItemReviewIndexPage";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router";
+import mockConsole from "tests/testutils/mockConsole";
+import { menuItemReviewFixtures } from "fixtures/menuItemReviewFixtures";
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
 
+const mockToast = vi.fn();
+vi.mock("react-toastify", async (importOriginal) => {
+  const originalModule = await importOriginal();
+  return {
+    ...originalModule,
+    toast: vi.fn((x) => mockToast(x)),
+  };
+});
+
 describe("MenuItemReviewIndexPage tests", () => {
   const axiosMock = new AxiosMockAdapter(axios);
+
+  const testId = "MenuItemReviewTable";
 
   const setupUserOnly = () => {
     axiosMock.reset();
@@ -22,13 +35,22 @@ describe("MenuItemReviewIndexPage tests", () => {
       .reply(200, systemInfoFixtures.showingNeither);
   };
 
+  const setupAdminUser = () => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.adminUser);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  };
+
   const queryClient = new QueryClient();
-  test("Renders expected content", async () => {
-    // arrange
 
-    setupUserOnly();
-
-    // act
+  test("Renders with Create Button for admin user", async () => {
+    setupAdminUser();
+    axiosMock.onGet("/api/menuitemreview/all").reply(200, []);
 
     render(
       <QueryClientProvider client={queryClient}>
@@ -38,13 +60,144 @@ describe("MenuItemReviewIndexPage tests", () => {
       </QueryClientProvider>,
     );
 
-    await screen.findByText("Index page not yet implemented");
+    await waitFor(() => {
+      expect(screen.getByText(/Create MenuItemReview/)).toBeInTheDocument();
+    });
+    const button = screen.getByText(/Create MenuItemReview/);
+    expect(button).toHaveAttribute("href", "/menuitemreviews/create");
+    expect(button).toHaveAttribute("style", "float: right;");
+  });
 
-    // assert
+  test("renders three menuitemreviews correctly for regular user", async () => {
+    setupUserOnly();
+    axiosMock
+      .onGet("/api/menuitemreview/all")
+      .reply(200, menuItemReviewFixtures.threeReviews);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <MenuItemReviewIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(`${testId}-cell-row-0-col-id`),
+      ).toHaveTextContent("1");
+    });
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent(
+      "2",
+    );
+    expect(screen.getByTestId(`${testId}-cell-row-2-col-id`)).toHaveTextContent(
+      "3",
+    );
+
+    const createMenuItemReviewButton = screen.queryByText(
+      "Create MenuItemReview",
+    );
+    expect(createMenuItemReviewButton).not.toBeInTheDocument();
+
     expect(
-      screen.getByText("Index page not yet implemented"),
-    ).toBeInTheDocument();
-    expect(screen.getByText("Create")).toBeInTheDocument();
-    expect(screen.getByText("Edit")).toBeInTheDocument();
+      screen.getByTestId(`${testId}-cell-row-0-col-itemId`),
+    ).toHaveTextContent("1");
+
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-reviewerEmail`),
+    ).toHaveTextContent("email@gmail.com");
+
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-stars`),
+    ).toHaveTextContent("4");
+
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-dateReviewed`),
+    ).toHaveTextContent("2022-01-02T12:00:00");
+
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-comments`),
+    ).toHaveTextContent("yum");
+
+    // for non-admin users, details button is visible, but the edit and delete buttons should not be visible
+    expect(
+      screen.queryByTestId("MenuItemReviewTable-cell-row-0-col-Delete-button"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("MenuItemReviewTable-cell-row-0-col-Edit-button"),
+    ).not.toBeInTheDocument();
+  });
+
+  test("renders empty table when backend unavailable, user only", async () => {
+    setupUserOnly();
+
+    axiosMock.onGet("/api/menuitemreview/all").timeout();
+
+    const restoreConsole = mockConsole();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <MenuItemReviewIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(1);
+    });
+
+    const errorMessage = console.error.mock.calls[0][0];
+    expect(errorMessage).toMatch(
+      "Error communicating with backend via GET on /api/menuitemreview/all",
+    );
+    restoreConsole();
+  });
+
+  test("what happens when you click delete, admin", async () => {
+    setupAdminUser();
+
+    axiosMock
+      .onGet("/api/menuitemreview/all")
+      .reply(200, menuItemReviewFixtures.threeReviews);
+    axiosMock
+      .onDelete("/api/menuItemReviews")
+      .reply(200, "MenuItemReview with id 1 was deleted");
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <MenuItemReviewIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(`${testId}-cell-row-0-col-id`),
+      ).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent(
+      "1",
+    );
+
+    const deleteButton = await screen.findByTestId(
+      `${testId}-cell-row-0-col-Delete-button`,
+    );
+    expect(deleteButton).toBeInTheDocument();
+
+    fireEvent.click(deleteButton);
+
+    await waitFor(() => {
+      expect(mockToast).toBeCalledWith("MenuItemReview with id 1 was deleted");
+    });
+
+    await waitFor(() => {
+      expect(axiosMock.history.delete.length).toBe(1);
+    });
+    expect(axiosMock.history.delete[0].url).toBe("/api/menuItemReviews");
+    expect(axiosMock.history.delete[0].url).toBe("/api/menuItemReviews");
+    expect(axiosMock.history.delete[0].params).toEqual({ id: 1 });
   });
 });


### PR DESCRIPTION
Closes #35.

In this PR we add the MenuItemReview index page.

To test, you can visit this dokku deployment.

https://team02-elissaalawi-dev.dokku-05.cs.ucsb.edu/

Visit the MenuItemReview index page. Create and delete should work properly.

<img width="1910" height="1016" alt="Index" src="https://github.com/user-attachments/assets/4682d25a-14b5-4761-9a4d-efced508104b" />
