### PR TITLE
Copy HelpRequest backend CRUD from team01 (#38)

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/HelpRequestController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/HelpRequestController.java
@@ -1,0 +1,133 @@
+package edu.ucsb.cs156.example.controllers;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import edu.ucsb.cs156.example.entities.HelpRequest;
+import edu.ucsb.cs156.example.errors.EntityNotFoundException;
+import edu.ucsb.cs156.example.repositories.HelpRequestRepository;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.time.LocalDateTime;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/** This is a REST controller for HelpRequests */
+@Tag(name = "HelpRequests")
+@RequestMapping("/api/helprequests")
+@RestController
+@Slf4j
+public class HelpRequestController extends ApiController {
+
+  @Autowired HelpRequestRepository helpRequestRepository;
+
+  /**
+   * List all help requests
+   *
+   * @return an iterable of HelpRequest
+   */
+  @Operation(summary = "List all help requests")
+  @PreAuthorize("hasRole('ROLE_USER')")
+  @GetMapping("/all")
+  public Iterable<HelpRequest> allHelpRequests() {
+    Iterable<HelpRequest> helpRequests = helpRequestRepository.findAll();
+    return helpRequests;
+  }
+
+  /**
+   * Create a new help request
+   *
+   * @param requesterEmail the requester email
+   * @param teamId the team id
+   * @param tableOrBreakoutRoom the table or breakout room
+   * @param requestTime the request time
+   * @param explanation the explanation
+   * @param solved the solved
+   * @return the saved help request
+   */
+  @Operation(summary = "Create a new help request")
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @PostMapping("/post")
+  public HelpRequest postHelpRequest(
+      @Parameter(name = "requesterEmail") @RequestParam String requesterEmail,
+      @Parameter(name = "teamId") @RequestParam String teamId,
+      @Parameter(name = "tableOrBreakoutRoom") @RequestParam String tableOrBreakoutRoom,
+      @Parameter(
+              name = "requestTime",
+              description =
+                  "date (in iso format, e.g. YYYY-mm-ddTHH:MM:SS; see https://en.wikipedia.org/wiki/ISO_8601)")
+          @RequestParam("requestTime")
+          @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+          LocalDateTime requestTime,
+      @Parameter(name = "explanation") @RequestParam String explanation,
+      @Parameter(name = "solved") @RequestParam boolean solved)
+      throws JsonProcessingException {
+
+    HelpRequest helpRequest = new HelpRequest();
+    helpRequest.setRequesterEmail(requesterEmail);
+    helpRequest.setTeamId(teamId);
+    helpRequest.setTableOrBreakoutRoom(tableOrBreakoutRoom);
+    helpRequest.setRequestTime(requestTime);
+    helpRequest.setExplanation(explanation);
+    helpRequest.setSolved(solved);
+
+    return helpRequestRepository.save(helpRequest);
+  }
+
+  /**
+   * Get a single help request by id
+   *
+   * @param id the id of the help request
+   * @return a HelpRequest
+   */
+  @Operation(summary = "Get a single help request")
+  @PreAuthorize("hasRole('ROLE_USER')")
+  @GetMapping("")
+  public HelpRequest getById(@Parameter(name = "id") @RequestParam Long id) {
+    HelpRequest helpRequest =
+        helpRequestRepository
+            .findById(id)
+            .orElseThrow(() -> new EntityNotFoundException(HelpRequest.class, id));
+
+    return helpRequest;
+  }
+
+  /**
+   * Update a single help request
+   *
+   * @param id id of the help request to update
+   * @param incoming the new help request values
+   * @return the updated help request
+   */
+  @Operation(summary = "Update a single help request")
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @PutMapping("")
+  public HelpRequest updateHelpRequest(
+      @Parameter(name = "id") @RequestParam Long id, @RequestBody @Valid HelpRequest incoming) {
+
+    HelpRequest helpRequest =
+        helpRequestRepository
+            .findById(id)
+            .orElseThrow(() -> new EntityNotFoundException(HelpRequest.class, id));
+
+    helpRequest.setRequesterEmail(incoming.getRequesterEmail());
+    helpRequest.setTeamId(incoming.getTeamId());
+    helpRequest.setTableOrBreakoutRoom(incoming.getTableOrBreakoutRoom());
+    helpRequest.setRequestTime(incoming.getRequestTime());
+    helpRequest.setExplanation(incoming.getExplanation());
+    helpRequest.setSolved(incoming.getSolved());
+
+    helpRequestRepository.save(helpRequest);
+
+    return helpRequest;
+  }
+}

--- a/src/main/java/edu/ucsb/cs156/example/entities/HelpRequest.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/HelpRequest.java
@@ -1,0 +1,30 @@
+package edu.ucsb.cs156.example.entities;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/** This is a JPA entity that represents HelpRequest */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity(name = "helprequests")
+public class HelpRequest {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private long id;
+
+  private String requesterEmail;
+  private String teamId;
+  private String tableOrBreakoutRoom;
+  private LocalDateTime requestTime;
+  private String explanation;
+  private boolean solved;
+}

--- a/src/main/java/edu/ucsb/cs156/example/repositories/HelpRequestRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/HelpRequestRepository.java
@@ -1,0 +1,11 @@
+package edu.ucsb.cs156.example.repositories;
+
+import edu.ucsb.cs156.example.entities.HelpRequest;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+import org.springframework.stereotype.Repository;
+
+/** The HelpRequestRepository is a repository for HelpRequest entities. */
+@Repository
+@RepositoryRestResource(exported = false)
+public interface HelpRequestRepository extends CrudRepository<HelpRequest, Long> {}

--- a/src/main/resources/db/migration/changes/HelpRequest.json
+++ b/src/main/resources/db/migration/changes/HelpRequest.json
@@ -1,0 +1,80 @@
+{
+    "databaseChangeLog": [
+      {
+        "changeSet": {
+          "id": "HelpRequest-1",
+          "author": "JohnKim04",
+          "preConditions": [
+            {
+              "onFail": "MARK_RAN"
+            },
+            {
+              "not": [
+                {
+                  "tableExists": {
+                    "tableName": "HELPREQUESTS"
+                  }
+                }
+              ]
+            }
+          ],
+          "changes": [
+            {
+              "createTable": {
+                "columns": [
+                  {
+                    "column": {
+                      "autoIncrement": true,
+                      "constraints": {
+                        "primaryKey": true,
+                        "primaryKeyName": "HELPREQUESTS_PK"
+                      },
+                      "name": "ID",
+                      "type": "BIGINT"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "REQUESTER_EMAIL",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "TEAM_ID",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "TABLE_OR_BREAKOUT_ROOM",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "REQUEST_TIME",
+                      "type": "TIMESTAMP"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "EXPLANATION",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "SOLVED",
+                      "type": "BOOLEAN"
+                    }
+                  }
+                ],
+                "tableName": "HELPREQUESTS"
+              }
+            }
+          ]
+        }
+      }
+    ]
+}

--- a/src/test/java/edu/ucsb/cs156/example/controllers/HelpRequestControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/HelpRequestControllerTests.java
@@ -1,0 +1,306 @@
+package edu.ucsb.cs156.example.controllers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.entities.HelpRequest;
+import edu.ucsb.cs156.example.repositories.HelpRequestRepository;
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MvcResult;
+
+@WebMvcTest(controllers = HelpRequestController.class)
+@Import(TestConfig.class)
+public class HelpRequestControllerTests extends ControllerTestCase {
+
+  @MockitoBean HelpRequestRepository helpRequestRepository;
+
+  @MockitoBean UserRepository userRepository;
+
+  // Authorization tests for /api/helprequests/all
+
+  @Test
+  public void logged_out_users_cannot_get_all() throws Exception {
+    mockMvc.perform(get("/api/helprequests/all")).andExpect(status().is(403));
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void logged_in_users_can_get_all() throws Exception {
+    mockMvc.perform(get("/api/helprequests/all")).andExpect(status().is(200));
+  }
+
+  // Authorization tests for /api/helprequests?id=...
+
+  @Test
+  public void logged_out_users_cannot_get_by_id() throws Exception {
+    mockMvc.perform(get("/api/helprequests").param("id", "7")).andExpect(status().is(403));
+  }
+
+  // Authorization tests for /api/helprequests/post
+
+  @Test
+  public void logged_out_users_cannot_post() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/helprequests/post")
+                .param("requesterEmail", "cgaucho@ucsb.edu")
+                .param("teamId", "s22-5pm-3")
+                .param("tableOrBreakoutRoom", "7")
+                .param("requestTime", "2022-04-20T17:35:00")
+                .param("explanation", "Need help with Swagger-ui")
+                .param("solved", "false")
+                .with(csrf()))
+        .andExpect(status().is(403));
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void logged_in_regular_users_cannot_post() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/helprequests/post")
+                .param("requesterEmail", "cgaucho@ucsb.edu")
+                .param("teamId", "s22-5pm-3")
+                .param("tableOrBreakoutRoom", "7")
+                .param("requestTime", "2022-04-20T17:35:00")
+                .param("explanation", "Need help with Swagger-ui")
+                .param("solved", "false")
+                .with(csrf()))
+        .andExpect(status().is(403));
+  }
+
+  // Tests with mocks for database actions
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void test_that_logged_in_user_can_get_by_id_when_the_id_exists() throws Exception {
+
+    LocalDateTime rt = LocalDateTime.parse("2022-04-20T17:35:00");
+
+    HelpRequest helpRequest =
+        HelpRequest.builder()
+            .requesterEmail("cgaucho@ucsb.edu")
+            .teamId("s22-5pm-3")
+            .tableOrBreakoutRoom("7")
+            .requestTime(rt)
+            .explanation("Need help with Swagger-ui")
+            .solved(true)
+            .build();
+
+    when(helpRequestRepository.findById(eq(7L))).thenReturn(Optional.of(helpRequest));
+
+    MvcResult response =
+        mockMvc
+            .perform(get("/api/helprequests").param("id", "7"))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    verify(helpRequestRepository, times(1)).findById(eq(7L));
+    String expectedJson = mapper.writeValueAsString(helpRequest);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void test_that_logged_in_user_can_get_by_id_when_the_id_does_not_exist() throws Exception {
+
+    when(helpRequestRepository.findById(eq(7L))).thenReturn(Optional.empty());
+
+    MvcResult response =
+        mockMvc
+            .perform(get("/api/helprequests").param("id", "7"))
+            .andExpect(status().isNotFound())
+            .andReturn();
+
+    verify(helpRequestRepository, times(1)).findById(eq(7L));
+    Map<String, Object> json = responseToJson(response);
+    assertEquals("EntityNotFoundException", json.get("type"));
+    assertEquals("HelpRequest with id 7 not found", json.get("message"));
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void logged_in_user_can_get_all_helprequests() throws Exception {
+
+    LocalDateTime rt1 = LocalDateTime.parse("2022-04-20T17:35:00");
+
+    HelpRequest helpRequest1 =
+        HelpRequest.builder()
+            .requesterEmail("cgaucho@ucsb.edu")
+            .teamId("s22-5pm-3")
+            .tableOrBreakoutRoom("7")
+            .requestTime(rt1)
+            .explanation("Need help with Swagger-ui")
+            .solved(false)
+            .build();
+
+    LocalDateTime rt2 = LocalDateTime.parse("2022-04-20T18:31:00");
+
+    HelpRequest helpRequest2 =
+        HelpRequest.builder()
+            .requesterEmail("ldelplaya@ucsb.edu")
+            .teamId("s22-6pm-3")
+            .tableOrBreakoutRoom("11")
+            .requestTime(rt2)
+            .explanation("Dokku problems")
+            .solved(false)
+            .build();
+
+    ArrayList<HelpRequest> expectedRequests = new ArrayList<>();
+    expectedRequests.addAll(Arrays.asList(helpRequest1, helpRequest2));
+
+    when(helpRequestRepository.findAll()).thenReturn(expectedRequests);
+
+    MvcResult response =
+        mockMvc.perform(get("/api/helprequests/all")).andExpect(status().isOk()).andReturn();
+
+    verify(helpRequestRepository, times(1)).findAll();
+    String expectedJson = mapper.writeValueAsString(expectedRequests);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void an_admin_user_can_post_a_new_helprequest() throws Exception {
+
+    LocalDateTime rt = LocalDateTime.parse("2022-04-20T17:35:00");
+
+    HelpRequest helpRequest =
+        HelpRequest.builder()
+            .requesterEmail("cgaucho@ucsb.edu")
+            .teamId("s22-5pm-3")
+            .tableOrBreakoutRoom("7")
+            .requestTime(rt)
+            .explanation("Need help with Swagger-ui")
+            .solved(true)
+            .build();
+
+    when(helpRequestRepository.save(eq(helpRequest))).thenReturn(helpRequest);
+
+    MvcResult response =
+        mockMvc
+            .perform(
+                post("/api/helprequests/post")
+                    .param("requesterEmail", "cgaucho@ucsb.edu")
+                    .param("teamId", "s22-5pm-3")
+                    .param("tableOrBreakoutRoom", "7")
+                    .param("requestTime", "2022-04-20T17:35:00")
+                    .param("explanation", "Need help with Swagger-ui")
+                    .param("solved", "true")
+                    .with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    verify(helpRequestRepository, times(1)).save(helpRequest);
+    String expectedJson = mapper.writeValueAsString(helpRequest);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void admin_can_edit_an_existing_helprequest() throws Exception {
+
+    LocalDateTime rt1 = LocalDateTime.parse("2022-04-20T17:35:00");
+    LocalDateTime rt2 = LocalDateTime.parse("2023-04-20T18:31:00");
+
+    HelpRequest helpRequestOrig =
+        HelpRequest.builder()
+            .requesterEmail("cgaucho@ucsb.edu")
+            .teamId("s22-5pm-3")
+            .tableOrBreakoutRoom("7")
+            .requestTime(rt1)
+            .explanation("Need help with Swagger-ui")
+            .solved(false)
+            .build();
+
+    HelpRequest helpRequestEdited =
+        HelpRequest.builder()
+            .requesterEmail("ldelplaya@ucsb.edu")
+            .teamId("s22-6pm-3")
+            .tableOrBreakoutRoom("11")
+            .requestTime(rt2)
+            .explanation("Dokku problems")
+            .solved(true)
+            .build();
+
+    String requestBody = mapper.writeValueAsString(helpRequestEdited);
+
+    when(helpRequestRepository.findById(eq(67L))).thenReturn(Optional.of(helpRequestOrig));
+
+    MvcResult response =
+        mockMvc
+            .perform(
+                put("/api/helprequests")
+                    .param("id", "67")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding("utf-8")
+                    .content(requestBody)
+                    .with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    verify(helpRequestRepository, times(1)).findById(67L);
+    verify(helpRequestRepository, times(1)).save(helpRequestEdited);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(requestBody, responseString);
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void admin_cannot_edit_helprequest_that_does_not_exist() throws Exception {
+
+    LocalDateTime rt = LocalDateTime.parse("2022-04-20T17:35:00");
+
+    HelpRequest helpRequestEdited =
+        HelpRequest.builder()
+            .requesterEmail("cgaucho@ucsb.edu")
+            .teamId("s22-5pm-3")
+            .tableOrBreakoutRoom("7")
+            .requestTime(rt)
+            .explanation("Need help with Swagger-ui")
+            .solved(true)
+            .build();
+
+    String requestBody = mapper.writeValueAsString(helpRequestEdited);
+
+    when(helpRequestRepository.findById(eq(67L))).thenReturn(Optional.empty());
+
+    MvcResult response =
+        mockMvc
+            .perform(
+                put("/api/helprequests")
+                    .param("id", "67")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding("utf-8")
+                    .content(requestBody)
+                    .with(csrf()))
+            .andExpect(status().isNotFound())
+            .andReturn();
+
+    verify(helpRequestRepository, times(1)).findById(67L);
+    Map<String, Object> json = responseToJson(response);
+    assertEquals("HelpRequest with id 67 not found", json.get("message"));
+  }
+}


### PR DESCRIPTION
Adds HelpRequest entity, repository, REST controller, controller tests, and Liquibase migration so the HelpRequest CRUD endpoints are exposed in Swagger.