### PR TITLE
Add HelpRequestForm component, tests, and stories (#40)

### DIFF
--- a/frontend/src/fixtures/helpRequestFixtures.js
+++ b/frontend/src/fixtures/helpRequestFixtures.js
@@ -1,0 +1,42 @@
+const helpRequestFixtures = {
+  oneHelpRequest: {
+    id: 1,
+    requesterEmail: "cgaucho@ucsb.edu",
+    teamId: "s26-5pm-3",
+    tableOrBreakoutRoom: "7",
+    requestTime: "2025-10-08T17:30:00",
+    explanation: "Need help with Swagger",
+    solved: false,
+  },
+  threeHelpRequests: [
+    {
+      id: 1,
+      requesterEmail: "cgaucho@ucsb.edu",
+      teamId: "s26-5pm-3",
+      tableOrBreakoutRoom: "7",
+      requestTime: "2025-10-08T17:30:00",
+      explanation: "Need help with Swagger",
+      solved: false,
+    },
+    {
+      id: 2,
+      requesterEmail: "ldelplaya@ucsb.edu",
+      teamId: "s26-6pm-4",
+      tableOrBreakoutRoom: "11",
+      requestTime: "2025-10-09T18:15:00",
+      explanation: "Heroku deployment issue",
+      solved: true,
+    },
+    {
+      id: 3,
+      requesterEmail: "pdewinter@ucsb.edu",
+      teamId: "s26-5pm-2",
+      tableOrBreakoutRoom: "Breakout Room 4",
+      requestTime: "2025-10-10T19:00:00",
+      explanation: "Merge conflict in App.js",
+      solved: false,
+    },
+  ],
+};
+
+export { helpRequestFixtures };

--- a/frontend/src/main/components/HelpRequest/HelpRequestForm.jsx
+++ b/frontend/src/main/components/HelpRequest/HelpRequestForm.jsx
@@ -1,0 +1,182 @@
+import { Button, Form } from "react-bootstrap";
+import { useForm } from "react-hook-form";
+import { useNavigate } from "react-router";
+
+function HelpRequestForm({
+  initialContents,
+  submitAction,
+  buttonLabel = "Create",
+}) {
+  // Stryker disable all
+  const defaultValues = initialContents
+    ? {
+        ...initialContents,
+        requestTime: initialContents.requestTime
+          ? initialContents.requestTime.replace("Z", "")
+          : "",
+      }
+    : {};
+
+  const {
+    register,
+    formState: { errors },
+    handleSubmit,
+  } = useForm({ defaultValues });
+  // Stryker restore all
+
+  const navigate = useNavigate();
+
+  const testIdPrefix = "HelpRequestForm";
+
+  // For explanation, see: https://stackoverflow.com/questions/3143070/javascript-regex-iso-datetime
+  // Note that even this complex regex may still need some tweaks
+
+  // Stryker disable Regex
+  const isodate_regex =
+    /(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d\.\d+)|(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d)|(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d)/i;
+  // Stryker restore Regex
+
+  // Stryker disable Regex
+  const email_regex = /^\S+@\S+\.\S+$/;
+  // Stryker restore Regex
+
+  return (
+    <Form onSubmit={handleSubmit(submitAction)}>
+      {initialContents && (
+        <Form.Group className="mb-3">
+          <Form.Label htmlFor="id">Id</Form.Label>
+          <Form.Control
+            data-testid={testIdPrefix + "-id"}
+            id="id"
+            type="text"
+            {...register("id")}
+            value={initialContents.id}
+            disabled
+          />
+        </Form.Group>
+      )}
+
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor="requesterEmail">Requester Email</Form.Label>
+        <Form.Control
+          data-testid={testIdPrefix + "-requesterEmail"}
+          id="requesterEmail"
+          type="text"
+          isInvalid={Boolean(errors.requesterEmail)}
+          {...register("requesterEmail", {
+            required: "Requester Email is required.",
+            pattern: {
+              value: email_regex,
+              message: "Requester Email must be a valid email address.",
+            },
+          })}
+        />
+        <Form.Control.Feedback type="invalid">
+          {errors.requesterEmail?.message}
+        </Form.Control.Feedback>
+      </Form.Group>
+
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor="teamId">Team Id</Form.Label>
+        <Form.Control
+          data-testid={testIdPrefix + "-teamId"}
+          id="teamId"
+          type="text"
+          isInvalid={Boolean(errors.teamId)}
+          {...register("teamId", {
+            required: "Team Id is required.",
+            maxLength: {
+              value: 30,
+              message: "Max length 30 characters",
+            },
+          })}
+        />
+        <Form.Control.Feedback type="invalid">
+          {errors.teamId?.message}
+        </Form.Control.Feedback>
+      </Form.Group>
+
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor="tableOrBreakoutRoom">
+          Table or Breakout Room
+        </Form.Label>
+        <Form.Control
+          data-testid={testIdPrefix + "-tableOrBreakoutRoom"}
+          id="tableOrBreakoutRoom"
+          type="text"
+          isInvalid={Boolean(errors.tableOrBreakoutRoom)}
+          {...register("tableOrBreakoutRoom", {
+            required: "Table or Breakout Room is required.",
+            maxLength: {
+              value: 50,
+              message: "Max length 50 characters",
+            },
+          })}
+        />
+        <Form.Control.Feedback type="invalid">
+          {errors.tableOrBreakoutRoom?.message}
+        </Form.Control.Feedback>
+      </Form.Group>
+
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor="requestTime">Request Time (iso format)</Form.Label>
+        <Form.Control
+          data-testid={testIdPrefix + "-requestTime"}
+          id="requestTime"
+          type="datetime-local"
+          isInvalid={Boolean(errors.requestTime)}
+          {...register("requestTime", {
+            required: true,
+            pattern: isodate_regex,
+          })}
+        />
+        <Form.Control.Feedback type="invalid">
+          {errors.requestTime && "Request Time is required. "}
+        </Form.Control.Feedback>
+      </Form.Group>
+
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor="explanation">Explanation</Form.Label>
+        <Form.Control
+          data-testid={testIdPrefix + "-explanation"}
+          id="explanation"
+          type="text"
+          isInvalid={Boolean(errors.explanation)}
+          {...register("explanation", {
+            required: "Explanation is required.",
+            maxLength: {
+              value: 255,
+              message: "Max length 255 characters",
+            },
+          })}
+        />
+        <Form.Control.Feedback type="invalid">
+          {errors.explanation?.message}
+        </Form.Control.Feedback>
+      </Form.Group>
+
+      <Form.Group className="mb-3">
+        <Form.Check
+          data-testid={testIdPrefix + "-solved"}
+          id="solved"
+          type="checkbox"
+          label="Solved"
+          {...register("solved")}
+        />
+      </Form.Group>
+
+      <Button type="submit" data-testid={testIdPrefix + "-submit"}>
+        {buttonLabel}
+      </Button>
+      <Button
+        variant="Secondary"
+        onClick={() => navigate(-1)}
+        data-testid={testIdPrefix + "-cancel"}
+      >
+        Cancel
+      </Button>
+    </Form>
+  );
+}
+
+export default HelpRequestForm;

--- a/frontend/src/stories/components/HelpRequest/HelpRequestForm.stories.jsx
+++ b/frontend/src/stories/components/HelpRequest/HelpRequestForm.stories.jsx
@@ -1,0 +1,33 @@
+import React from "react";
+import HelpRequestForm from "main/components/HelpRequest/HelpRequestForm";
+import { helpRequestFixtures } from "fixtures/helpRequestFixtures";
+
+export default {
+  title: "components/HelpRequest/HelpRequestForm",
+  component: HelpRequestForm,
+};
+
+const Template = (args) => {
+  return <HelpRequestForm {...args} />;
+};
+
+export const Create = Template.bind({});
+
+Create.args = {
+  buttonLabel: "Create",
+  submitAction: (data) => {
+    console.log("Submit was clicked with data: ", data);
+    window.alert("Submit was clicked with data: " + JSON.stringify(data));
+  },
+};
+
+export const Update = Template.bind({});
+
+Update.args = {
+  initialContents: helpRequestFixtures.oneHelpRequest,
+  buttonLabel: "Update",
+  submitAction: (data) => {
+    console.log("Submit was clicked with data: ", data);
+    window.alert("Submit was clicked with data: " + JSON.stringify(data));
+  },
+};

--- a/frontend/src/tests/components/HelpRequest/HelpRequestForm.test.jsx
+++ b/frontend/src/tests/components/HelpRequest/HelpRequestForm.test.jsx
@@ -42,9 +42,7 @@ describe("HelpRequestForm tests", () => {
   test("renders correctly when passing in initialContents", async () => {
     render(
       <Router>
-        <HelpRequestForm
-          initialContents={helpRequestFixtures.oneHelpRequest}
-        />
+        <HelpRequestForm initialContents={helpRequestFixtures.oneHelpRequest} />
       </Router>,
     );
 
@@ -71,9 +69,7 @@ describe("HelpRequestForm tests", () => {
         />
       </Router>,
     );
-    const requestTimeField = await screen.findByTestId(
-      `${testId}-requestTime`,
-    );
+    const requestTimeField = await screen.findByTestId(`${testId}-requestTime`);
     expect(requestTimeField.value.startsWith("2025-10-08T17:30")).toBe(true);
     expect(requestTimeField.value.endsWith("Z")).toBe(false);
   });
@@ -84,9 +80,7 @@ describe("HelpRequestForm tests", () => {
         <HelpRequestForm initialContents={{ id: 7 }} />
       </Router>,
     );
-    const requestTimeField = await screen.findByTestId(
-      `${testId}-requestTime`,
-    );
+    const requestTimeField = await screen.findByTestId(`${testId}-requestTime`);
     expect(requestTimeField).toHaveValue("");
     expect(screen.getByTestId(`${testId}-id`)).toHaveValue("7");
   });
@@ -133,23 +127,21 @@ describe("HelpRequestForm tests", () => {
 
     const submitButton = await screen.findByTestId(`${testId}-submit`);
 
-    const requesterEmailField = screen.getByTestId(
-      `${testId}-requesterEmail`,
-    );
+    const requesterEmailField = screen.getByTestId(`${testId}-requesterEmail`);
     const teamIdField = screen.getByTestId(`${testId}-teamId`);
     const tableField = screen.getByTestId(`${testId}-tableOrBreakoutRoom`);
     const explanationField = screen.getByTestId(`${testId}-explanation`);
 
-    fireEvent.change(requesterEmailField, { target: { value: "not-an-email" } });
+    fireEvent.change(requesterEmailField, {
+      target: { value: "not-an-email" },
+    });
     fireEvent.change(teamIdField, { target: { value: "a".repeat(31) } });
     fireEvent.change(tableField, { target: { value: "b".repeat(51) } });
     fireEvent.change(explanationField, { target: { value: "c".repeat(256) } });
 
     fireEvent.click(submitButton);
 
-    await screen.findByText(
-      /Requester Email must be a valid email address\./,
-    );
+    await screen.findByText(/Requester Email must be a valid email address\./);
     expect(screen.getByText(/Max length 30 characters/)).toBeInTheDocument();
     expect(screen.getByText(/Max length 50 characters/)).toBeInTheDocument();
     expect(screen.getByText(/Max length 255 characters/)).toBeInTheDocument();

--- a/frontend/src/tests/components/HelpRequest/HelpRequestForm.test.jsx
+++ b/frontend/src/tests/components/HelpRequest/HelpRequestForm.test.jsx
@@ -1,0 +1,201 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { BrowserRouter as Router } from "react-router";
+
+import HelpRequestForm from "main/components/HelpRequest/HelpRequestForm";
+import { helpRequestFixtures } from "fixtures/helpRequestFixtures";
+
+const mockedNavigate = vi.fn();
+vi.mock("react-router", async () => {
+  const originalModule = await vi.importActual("react-router");
+  return {
+    ...originalModule,
+    useNavigate: () => mockedNavigate,
+  };
+});
+
+describe("HelpRequestForm tests", () => {
+  const expectedHeaders = [
+    "Requester Email",
+    "Team Id",
+    "Table or Breakout Room",
+    "Request Time (iso format)",
+    "Explanation",
+    "Solved",
+  ];
+  const testId = "HelpRequestForm";
+
+  test("renders correctly with no initialContents", async () => {
+    render(
+      <Router>
+        <HelpRequestForm />
+      </Router>,
+    );
+
+    expect(await screen.findByText(/Create/)).toBeInTheDocument();
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+  });
+
+  test("renders correctly when passing in initialContents", async () => {
+    render(
+      <Router>
+        <HelpRequestForm
+          initialContents={helpRequestFixtures.oneHelpRequest}
+        />
+      </Router>,
+    );
+
+    expect(await screen.findByText(/Create/)).toBeInTheDocument();
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expect(await screen.findByTestId(`${testId}-id`)).toBeInTheDocument();
+    expect(screen.getByText(`Id`)).toBeInTheDocument();
+    expect(screen.getByTestId(`${testId}-id`)).toHaveValue("1");
+  });
+
+  test("strips trailing Z from requestTime when passed in initialContents", async () => {
+    render(
+      <Router>
+        <HelpRequestForm
+          initialContents={{
+            ...helpRequestFixtures.oneHelpRequest,
+            requestTime: "2025-10-08T17:30:00Z",
+          }}
+        />
+      </Router>,
+    );
+    const requestTimeField = await screen.findByTestId(
+      `${testId}-requestTime`,
+    );
+    expect(requestTimeField.value.startsWith("2025-10-08T17:30")).toBe(true);
+    expect(requestTimeField.value.endsWith("Z")).toBe(false);
+  });
+
+  test("falls back to empty requestTime when initialContents has none", async () => {
+    render(
+      <Router>
+        <HelpRequestForm initialContents={{ id: 7 }} />
+      </Router>,
+    );
+    const requestTimeField = await screen.findByTestId(
+      `${testId}-requestTime`,
+    );
+    expect(requestTimeField).toHaveValue("");
+    expect(screen.getByTestId(`${testId}-id`)).toHaveValue("7");
+  });
+
+  test("that navigate(-1) is called when Cancel is clicked", async () => {
+    render(
+      <Router>
+        <HelpRequestForm />
+      </Router>,
+    );
+    expect(await screen.findByTestId(`${testId}-cancel`)).toBeInTheDocument();
+    const cancelButton = screen.getByTestId(`${testId}-cancel`);
+
+    fireEvent.click(cancelButton);
+
+    await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith(-1));
+  });
+
+  test("required field error messages on empty submit", async () => {
+    render(
+      <Router>
+        <HelpRequestForm />
+      </Router>,
+    );
+
+    const submitButton = await screen.findByTestId(`${testId}-submit`);
+    fireEvent.click(submitButton);
+
+    await screen.findByText(/Requester Email is required\./);
+    expect(screen.getByText(/Team Id is required\./)).toBeInTheDocument();
+    expect(
+      screen.getByText(/Table or Breakout Room is required\./),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Request Time is required\./)).toBeInTheDocument();
+    expect(screen.getByText(/Explanation is required\./)).toBeInTheDocument();
+  });
+
+  test("bad-input validation messages", async () => {
+    render(
+      <Router>
+        <HelpRequestForm />
+      </Router>,
+    );
+
+    const submitButton = await screen.findByTestId(`${testId}-submit`);
+
+    const requesterEmailField = screen.getByTestId(
+      `${testId}-requesterEmail`,
+    );
+    const teamIdField = screen.getByTestId(`${testId}-teamId`);
+    const tableField = screen.getByTestId(`${testId}-tableOrBreakoutRoom`);
+    const explanationField = screen.getByTestId(`${testId}-explanation`);
+
+    fireEvent.change(requesterEmailField, { target: { value: "not-an-email" } });
+    fireEvent.change(teamIdField, { target: { value: "a".repeat(31) } });
+    fireEvent.change(tableField, { target: { value: "b".repeat(51) } });
+    fireEvent.change(explanationField, { target: { value: "c".repeat(256) } });
+
+    fireEvent.click(submitButton);
+
+    await screen.findByText(
+      /Requester Email must be a valid email address\./,
+    );
+    expect(screen.getByText(/Max length 30 characters/)).toBeInTheDocument();
+    expect(screen.getByText(/Max length 50 characters/)).toBeInTheDocument();
+    expect(screen.getByText(/Max length 255 characters/)).toBeInTheDocument();
+  });
+
+  test("submitAction is called with valid input", async () => {
+    const mockSubmitAction = vi.fn();
+
+    render(
+      <Router>
+        <HelpRequestForm submitAction={mockSubmitAction} />
+      </Router>,
+    );
+
+    const requesterEmailField = await screen.findByTestId(
+      `${testId}-requesterEmail`,
+    );
+    const teamIdField = screen.getByTestId(`${testId}-teamId`);
+    const tableField = screen.getByTestId(`${testId}-tableOrBreakoutRoom`);
+    const requestTimeField = screen.getByTestId(`${testId}-requestTime`);
+    const explanationField = screen.getByTestId(`${testId}-explanation`);
+    const solvedField = screen.getByTestId(`${testId}-solved`);
+    const submitButton = screen.getByTestId(`${testId}-submit`);
+
+    fireEvent.change(requesterEmailField, {
+      target: { value: "cgaucho@ucsb.edu" },
+    });
+    fireEvent.change(teamIdField, { target: { value: "s26-5pm-3" } });
+    fireEvent.change(tableField, { target: { value: "7" } });
+    fireEvent.change(requestTimeField, {
+      target: { value: "2025-10-08T17:30" },
+    });
+    fireEvent.change(explanationField, {
+      target: { value: "Need help with Swagger" },
+    });
+    fireEvent.click(solvedField);
+
+    fireEvent.click(submitButton);
+
+    await waitFor(() => expect(mockSubmitAction).toHaveBeenCalled());
+
+    expect(
+      screen.queryByText(/Requester Email is required\./),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/Requester Email must be a valid email address\./),
+    ).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Closes #40
## Summary
- Adds HelpRequestForm under frontend/src/main/components/HelpRequest/ with all 6 entity fields, validations, datetime-local picker, and a checkbox for `solved`.
- Adds Vitest tests (8 tests, 100% line/branch/function coverage on the new file).
- Adds Storybook Create and Update stories.
## Test plan
- npx vitest run (139/139 passed, 100% global coverage)
- npx eslint --fix on src/main/components/HelpRequest/, src/tests/components/HelpRequest/, src/stories/components/HelpRequest/
- npm run storybook -> visually inspect Create and Update stories (screenshot below)
- (optional) npx stryker run -m src/main/components/HelpRequest/HelpRequestForm.jsx

<img width="739" height="632" alt="Screenshot 2026-05-04 at 8 03 46 PM" src="https://github.com/user-attachments/assets/40b43285-132d-41a9-b426-4e62e95bff8d" />

https://www.chromatic.com/build?appId=69f3ecdac277d89602812712&number=39
