### PR TITLE
Add HelpRequestTable component, tests, and stories (#41)

### DIFF
--- a/frontend/src/fixtures/helpRequestFixtures.js
+++ b/frontend/src/fixtures/helpRequestFixtures.js
@@ -1,0 +1,42 @@
+const helpRequestFixtures = {
+  oneHelpRequest: {
+    id: 1,
+    requesterEmail: "cgaucho@ucsb.edu",
+    teamId: "s26-5pm-3",
+    tableOrBreakoutRoom: "7",
+    requestTime: "2025-10-08T17:30:00",
+    explanation: "Need help with Swagger",
+    solved: false,
+  },
+  threeHelpRequests: [
+    {
+      id: 1,
+      requesterEmail: "cgaucho@ucsb.edu",
+      teamId: "s26-5pm-3",
+      tableOrBreakoutRoom: "7",
+      requestTime: "2025-10-08T17:30:00",
+      explanation: "Need help with Swagger",
+      solved: false,
+    },
+    {
+      id: 2,
+      requesterEmail: "ldelplaya@ucsb.edu",
+      teamId: "s26-6pm-4",
+      tableOrBreakoutRoom: "11",
+      requestTime: "2025-10-09T18:15:00",
+      explanation: "Heroku deployment issue",
+      solved: true,
+    },
+    {
+      id: 3,
+      requesterEmail: "pdewinter@ucsb.edu",
+      teamId: "s26-5pm-2",
+      tableOrBreakoutRoom: "Breakout Room 4",
+      requestTime: "2025-10-10T19:00:00",
+      explanation: "Merge conflict in App.js",
+      solved: false,
+    },
+  ],
+};
+
+export { helpRequestFixtures };

--- a/frontend/src/main/components/HelpRequest/HelpRequestTable.jsx
+++ b/frontend/src/main/components/HelpRequest/HelpRequestTable.jsx
@@ -1,0 +1,78 @@
+import React from "react";
+import OurTable, { ButtonColumn } from "main/components/OurTable";
+
+import { useBackendMutation } from "main/utils/useBackend";
+import {
+  cellToAxiosParamsDelete,
+  onDeleteSuccess,
+} from "main/utils/helpRequestUtils";
+import { useNavigate } from "react-router";
+import { hasRole } from "main/utils/useCurrentUser";
+
+export default function HelpRequestTable({
+  helpRequests,
+  currentUser,
+  testIdPrefix = "HelpRequestTable",
+}) {
+  const navigate = useNavigate();
+
+  const editCallback = (cell) => {
+    navigate(`/helprequests/edit/${cell.row.original.id}`);
+  };
+
+  // Stryker disable all : hard to test for query caching
+
+  const deleteMutation = useBackendMutation(
+    cellToAxiosParamsDelete,
+    { onSuccess: onDeleteSuccess },
+    ["/api/helprequests/all"],
+  );
+  // Stryker restore all
+
+  // Stryker disable next-line all : TODO try to make a good test for this
+  const deleteCallback = async (cell) => {
+    deleteMutation.mutate(cell);
+  };
+
+  const columns = [
+    {
+      header: "id",
+      accessorKey: "id",
+    },
+    {
+      header: "Requester Email",
+      accessorKey: "requesterEmail",
+    },
+    {
+      header: "Team Id",
+      accessorKey: "teamId",
+    },
+    {
+      header: "Table or Breakout Room",
+      accessorKey: "tableOrBreakoutRoom",
+    },
+    {
+      header: "Request Time",
+      accessorKey: "requestTime",
+    },
+    {
+      header: "Explanation",
+      accessorKey: "explanation",
+    },
+    {
+      header: "Solved",
+      accessorKey: "solved",
+    },
+  ];
+
+  if (hasRole(currentUser, "ROLE_ADMIN")) {
+    columns.push(ButtonColumn("Edit", "primary", editCallback, testIdPrefix));
+    columns.push(
+      ButtonColumn("Delete", "danger", deleteCallback, testIdPrefix),
+    );
+  }
+
+  return (
+    <OurTable data={helpRequests} columns={columns} testid={testIdPrefix} />
+  );
+}

--- a/frontend/src/main/utils/helpRequestUtils.js
+++ b/frontend/src/main/utils/helpRequestUtils.js
@@ -1,0 +1,16 @@
+import { toast } from "react-toastify";
+
+export function onDeleteSuccess(message) {
+  console.log(message);
+  toast(message);
+}
+
+export function cellToAxiosParamsDelete(cell) {
+  return {
+    url: "/api/helprequests",
+    method: "DELETE",
+    params: {
+      id: cell.row.original.id,
+    },
+  };
+}

--- a/frontend/src/stories/components/HelpRequest/HelpRequestTable.stories.jsx
+++ b/frontend/src/stories/components/HelpRequest/HelpRequestTable.stories.jsx
@@ -1,0 +1,45 @@
+import React from "react";
+import HelpRequestTable from "main/components/HelpRequest/HelpRequestTable";
+import { helpRequestFixtures } from "fixtures/helpRequestFixtures";
+import { currentUserFixtures } from "fixtures/currentUserFixtures";
+import { http, HttpResponse } from "msw";
+
+export default {
+  title: "components/HelpRequest/HelpRequestTable",
+  component: HelpRequestTable,
+};
+
+const Template = (args) => {
+  return <HelpRequestTable {...args} />;
+};
+
+export const Empty = Template.bind({});
+
+Empty.args = {
+  helpRequests: [],
+  currentUser: currentUserFixtures.userOnly,
+};
+
+export const ThreeItemsOrdinaryUser = Template.bind({});
+
+ThreeItemsOrdinaryUser.args = {
+  helpRequests: helpRequestFixtures.threeHelpRequests,
+  currentUser: currentUserFixtures.userOnly,
+};
+
+export const ThreeItemsAdminUser = Template.bind({});
+ThreeItemsAdminUser.args = {
+  helpRequests: helpRequestFixtures.threeHelpRequests,
+  currentUser: currentUserFixtures.adminUser,
+};
+
+ThreeItemsAdminUser.parameters = {
+  msw: [
+    http.delete("/api/helprequests", () => {
+      return HttpResponse.json(
+        { message: "Help Request deleted successfully" },
+        { status: 200 },
+      );
+    }),
+  ],
+};

--- a/frontend/src/tests/components/HelpRequest/HelpRequestTable.test.jsx
+++ b/frontend/src/tests/components/HelpRequest/HelpRequestTable.test.jsx
@@ -1,0 +1,225 @@
+import { fireEvent, render, waitFor, screen } from "@testing-library/react";
+import { helpRequestFixtures } from "fixtures/helpRequestFixtures";
+import HelpRequestTable from "main/components/HelpRequest/HelpRequestTable";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router";
+import { currentUserFixtures } from "fixtures/currentUserFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+const mockedNavigate = vi.fn();
+vi.mock("react-router", async () => {
+  const originalModule = await vi.importActual("react-router");
+  return {
+    ...originalModule,
+    useNavigate: () => mockedNavigate,
+  };
+});
+
+describe("HelpRequestTable tests", () => {
+  const queryClient = new QueryClient();
+
+  const expectedHeaders = [
+    "id",
+    "Requester Email",
+    "Team Id",
+    "Table or Breakout Room",
+    "Request Time",
+    "Explanation",
+    "Solved",
+  ];
+  const expectedFields = [
+    "id",
+    "requesterEmail",
+    "teamId",
+    "tableOrBreakoutRoom",
+    "requestTime",
+    "explanation",
+    "solved",
+  ];
+  const testId = "HelpRequestTable";
+
+  test("renders empty table correctly", () => {
+    const currentUser = currentUserFixtures.adminUser;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <HelpRequestTable helpRequests={[]} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const fieldElement = screen.queryByTestId(
+        `${testId}-cell-row-0-col-${field}`,
+      );
+      expect(fieldElement).not.toBeInTheDocument();
+    });
+  });
+
+  test("Has the expected column headers, content and buttons for admin user", () => {
+    const currentUser = currentUserFixtures.adminUser;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <HelpRequestTable
+            helpRequests={helpRequestFixtures.threeHelpRequests}
+            currentUser={currentUser}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(header).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent(
+      "1",
+    );
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-teamId`),
+    ).toHaveTextContent("s26-5pm-3");
+
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent(
+      "2",
+    );
+    expect(
+      screen.getByTestId(`${testId}-cell-row-1-col-teamId`),
+    ).toHaveTextContent("s26-6pm-4");
+
+    const editButton = screen.getByTestId(
+      `${testId}-cell-row-0-col-Edit-button`,
+    );
+    expect(editButton).toBeInTheDocument();
+    expect(editButton).toHaveClass("btn-primary");
+
+    const deleteButton = screen.getByTestId(
+      `${testId}-cell-row-0-col-Delete-button`,
+    );
+    expect(deleteButton).toBeInTheDocument();
+    expect(deleteButton).toHaveClass("btn-danger");
+  });
+
+  test("Has the expected column headers, content for ordinary user", () => {
+    const currentUser = currentUserFixtures.userOnly;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <HelpRequestTable
+            helpRequests={helpRequestFixtures.threeHelpRequests}
+            currentUser={currentUser}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(header).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent(
+      "1",
+    );
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-teamId`),
+    ).toHaveTextContent("s26-5pm-3");
+
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent(
+      "2",
+    );
+    expect(
+      screen.getByTestId(`${testId}-cell-row-1-col-teamId`),
+    ).toHaveTextContent("s26-6pm-4");
+
+    expect(screen.queryByText("Delete")).not.toBeInTheDocument();
+    expect(screen.queryByText("Edit")).not.toBeInTheDocument();
+  });
+
+  test("Edit button navigates to the edit page", async () => {
+    const currentUser = currentUserFixtures.adminUser;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <HelpRequestTable
+            helpRequests={helpRequestFixtures.threeHelpRequests}
+            currentUser={currentUser}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expect(
+      await screen.findByTestId(`${testId}-cell-row-0-col-id`),
+    ).toHaveTextContent("1");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-teamId`),
+    ).toHaveTextContent("s26-5pm-3");
+
+    const editButton = screen.getByTestId(
+      `${testId}-cell-row-0-col-Edit-button`,
+    );
+    expect(editButton).toBeInTheDocument();
+
+    fireEvent.click(editButton);
+
+    await waitFor(() =>
+      expect(mockedNavigate).toHaveBeenCalledWith("/helprequests/edit/1"),
+    );
+  });
+
+  test("Delete button calls delete callback", async () => {
+    const currentUser = currentUserFixtures.adminUser;
+
+    const axiosMock = new AxiosMockAdapter(axios);
+    axiosMock
+      .onDelete("/api/helprequests")
+      .reply(200, { message: "Help Request deleted" });
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <HelpRequestTable
+            helpRequests={helpRequestFixtures.threeHelpRequests}
+            currentUser={currentUser}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expect(
+      await screen.findByTestId(`${testId}-cell-row-0-col-id`),
+    ).toHaveTextContent("1");
+
+    const deleteButton = screen.getByTestId(
+      `${testId}-cell-row-0-col-Delete-button`,
+    );
+    expect(deleteButton).toBeInTheDocument();
+
+    fireEvent.click(deleteButton);
+
+    await waitFor(() => expect(axiosMock.history.delete.length).toBe(1));
+    expect(axiosMock.history.delete[0].params).toEqual({ id: 1 });
+  });
+});

--- a/frontend/src/tests/utils/helpRequestUtils.test.jsx
+++ b/frontend/src/tests/utils/helpRequestUtils.test.jsx
@@ -1,0 +1,44 @@
+import {
+  onDeleteSuccess,
+  cellToAxiosParamsDelete,
+} from "main/utils/helpRequestUtils";
+import mockConsole from "tests/testutils/mockConsole";
+
+const mockToast = vi.fn();
+vi.mock("react-toastify", async (importOriginal) => {
+  const originalModule = await importOriginal();
+  return {
+    ...originalModule,
+    toast: vi.fn((x) => mockToast(x)),
+  };
+});
+
+describe("HelpRequestUtils", () => {
+  describe("onDeleteSuccess", () => {
+    test("It puts the message on console.log and in a toast", () => {
+      const restoreConsole = mockConsole();
+
+      onDeleteSuccess("abc");
+
+      expect(mockToast).toHaveBeenCalledWith("abc");
+      expect(console.log).toHaveBeenCalled();
+      const message = console.log.mock.calls[0][0];
+      expect(message).toMatch("abc");
+
+      restoreConsole();
+    });
+  });
+  describe("cellToAxiosParamsDelete", () => {
+    test("It returns the correct params", () => {
+      const cell = { row: { original: { id: 17 } } };
+
+      const result = cellToAxiosParamsDelete(cell);
+
+      expect(result).toEqual({
+        url: "/api/helprequests",
+        method: "DELETE",
+        params: { id: 17 },
+      });
+    });
+  });
+});


### PR DESCRIPTION
Closes #41

## Summary
- Adds `HelpRequestTable` with columns for id, requesterEmail, teamId, tableOrBreakoutRoom, requestTime, explanation, and solved.
- Admins get Edit (navigates to `/helprequests/edit/:id`) and Delete (`DELETE /api/helprequests` with `id` param, invalidates `/api/helprequests/all`).
- Adds `helpRequestUtils.js` (toast + axios delete params), matching the MenuItemReview pattern.
- Storybook: Empty, ThreeItemsOrdinaryUser, ThreeItemsAdminUser (MSW mocks delete for admin story).

## Test plan
- `npx vitest run` (138 tests, 100% coverage)
- `npm run check-format`
- `npm run storybook` — confirm HelpRequestTable stories
<img width="1901" height="544" alt="Screenshot 2026-05-04 at 8 28 28 PM" src="https://github.com/user-attachments/assets/420e85cc-db51-4954-9f6e-d04303d78d27" />

