### PR TITLE
Create Page for HelpRequest plus tests and stories (#43)

### DIFF
--- a/frontend/src/fixtures/helpRequestFixtures.js
+++ b/frontend/src/fixtures/helpRequestFixtures.js
@@ -1,0 +1,42 @@
+const helpRequestFixtures = {
+  oneHelpRequest: {
+    id: 1,
+    requesterEmail: "cgaucho@ucsb.edu",
+    teamId: "s26-5pm-3",
+    tableOrBreakoutRoom: "7",
+    requestTime: "2025-10-08T17:30:00",
+    explanation: "Need help with Swagger",
+    solved: false,
+  },
+  threeHelpRequests: [
+    {
+      id: 1,
+      requesterEmail: "cgaucho@ucsb.edu",
+      teamId: "s26-5pm-3",
+      tableOrBreakoutRoom: "7",
+      requestTime: "2025-10-08T17:30:00",
+      explanation: "Need help with Swagger",
+      solved: false,
+    },
+    {
+      id: 2,
+      requesterEmail: "ldelplaya@ucsb.edu",
+      teamId: "s26-6pm-4",
+      tableOrBreakoutRoom: "11",
+      requestTime: "2025-10-09T18:15:00",
+      explanation: "Heroku deployment issue",
+      solved: true,
+    },
+    {
+      id: 3,
+      requesterEmail: "pdewinter@ucsb.edu",
+      teamId: "s26-5pm-2",
+      tableOrBreakoutRoom: "Breakout Room 4",
+      requestTime: "2025-10-10T19:00:00",
+      explanation: "Merge conflict in App.js",
+      solved: false,
+    },
+  ],
+};
+
+export { helpRequestFixtures };

--- a/frontend/src/main/components/HelpRequest/HelpRequestForm.jsx
+++ b/frontend/src/main/components/HelpRequest/HelpRequestForm.jsx
@@ -1,0 +1,182 @@
+import { Button, Form } from "react-bootstrap";
+import { useForm } from "react-hook-form";
+import { useNavigate } from "react-router";
+
+function HelpRequestForm({
+  initialContents,
+  submitAction,
+  buttonLabel = "Create",
+}) {
+  // Stryker disable all
+  const defaultValues = initialContents
+    ? {
+        ...initialContents,
+        requestTime: initialContents.requestTime
+          ? initialContents.requestTime.replace("Z", "")
+          : "",
+      }
+    : { solved: false };
+
+  const {
+    register,
+    formState: { errors },
+    handleSubmit,
+  } = useForm({ defaultValues });
+  // Stryker restore all
+
+  const navigate = useNavigate();
+
+  const testIdPrefix = "HelpRequestForm";
+
+  // For explanation, see: https://stackoverflow.com/questions/3143070/javascript-regex-iso-datetime
+  // Note that even this complex regex may still need some tweaks
+
+  // Stryker disable Regex
+  const isodate_regex =
+    /(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d\.\d+)|(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d)|(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d)/i;
+  // Stryker restore Regex
+
+  // Stryker disable Regex
+  const email_regex = /^\S+@\S+\.\S+$/;
+  // Stryker restore Regex
+
+  return (
+    <Form onSubmit={handleSubmit(submitAction)}>
+      {initialContents && (
+        <Form.Group className="mb-3">
+          <Form.Label htmlFor="id">Id</Form.Label>
+          <Form.Control
+            data-testid={testIdPrefix + "-id"}
+            id="id"
+            type="text"
+            {...register("id")}
+            value={initialContents.id}
+            disabled
+          />
+        </Form.Group>
+      )}
+
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor="requesterEmail">Requester Email</Form.Label>
+        <Form.Control
+          data-testid={testIdPrefix + "-requesterEmail"}
+          id="requesterEmail"
+          type="text"
+          isInvalid={Boolean(errors.requesterEmail)}
+          {...register("requesterEmail", {
+            required: "Requester Email is required.",
+            pattern: {
+              value: email_regex,
+              message: "Requester Email must be a valid email address.",
+            },
+          })}
+        />
+        <Form.Control.Feedback type="invalid">
+          {errors.requesterEmail?.message}
+        </Form.Control.Feedback>
+      </Form.Group>
+
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor="teamId">Team Id</Form.Label>
+        <Form.Control
+          data-testid={testIdPrefix + "-teamId"}
+          id="teamId"
+          type="text"
+          isInvalid={Boolean(errors.teamId)}
+          {...register("teamId", {
+            required: "Team Id is required.",
+            maxLength: {
+              value: 30,
+              message: "Max length 30 characters",
+            },
+          })}
+        />
+        <Form.Control.Feedback type="invalid">
+          {errors.teamId?.message}
+        </Form.Control.Feedback>
+      </Form.Group>
+
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor="tableOrBreakoutRoom">
+          Table or Breakout Room
+        </Form.Label>
+        <Form.Control
+          data-testid={testIdPrefix + "-tableOrBreakoutRoom"}
+          id="tableOrBreakoutRoom"
+          type="text"
+          isInvalid={Boolean(errors.tableOrBreakoutRoom)}
+          {...register("tableOrBreakoutRoom", {
+            required: "Table or Breakout Room is required.",
+            maxLength: {
+              value: 50,
+              message: "Max length 50 characters",
+            },
+          })}
+        />
+        <Form.Control.Feedback type="invalid">
+          {errors.tableOrBreakoutRoom?.message}
+        </Form.Control.Feedback>
+      </Form.Group>
+
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor="requestTime">Request Time (iso format)</Form.Label>
+        <Form.Control
+          data-testid={testIdPrefix + "-requestTime"}
+          id="requestTime"
+          type="datetime-local"
+          isInvalid={Boolean(errors.requestTime)}
+          {...register("requestTime", {
+            required: true,
+            pattern: isodate_regex,
+          })}
+        />
+        <Form.Control.Feedback type="invalid">
+          {errors.requestTime && "Request Time is required. "}
+        </Form.Control.Feedback>
+      </Form.Group>
+
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor="explanation">Explanation</Form.Label>
+        <Form.Control
+          data-testid={testIdPrefix + "-explanation"}
+          id="explanation"
+          type="text"
+          isInvalid={Boolean(errors.explanation)}
+          {...register("explanation", {
+            required: "Explanation is required.",
+            maxLength: {
+              value: 255,
+              message: "Max length 255 characters",
+            },
+          })}
+        />
+        <Form.Control.Feedback type="invalid">
+          {errors.explanation?.message}
+        </Form.Control.Feedback>
+      </Form.Group>
+
+      <Form.Group className="mb-3">
+        <Form.Check
+          data-testid={testIdPrefix + "-solved"}
+          id="solved"
+          type="checkbox"
+          label="Solved"
+          {...register("solved")}
+        />
+      </Form.Group>
+
+      <Button type="submit" data-testid={testIdPrefix + "-submit"}>
+        {buttonLabel}
+      </Button>
+      <Button
+        variant="Secondary"
+        onClick={() => navigate(-1)}
+        data-testid={testIdPrefix + "-cancel"}
+      >
+        Cancel
+      </Button>
+    </Form>
+  );
+}
+
+export default HelpRequestForm;

--- a/frontend/src/main/pages/HelpRequest/HelpRequestCreatePage.jsx
+++ b/frontend/src/main/pages/HelpRequest/HelpRequestCreatePage.jsx
@@ -1,11 +1,51 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import HelpRequestForm from "main/components/HelpRequest/HelpRequestForm";
+import { Navigate } from "react-router";
+import { useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
 
-export default function HelpRequestCreatePage() {
-  // Stryker disable all : placeholder for future implementation
+export default function HelpRequestCreatePage({ storybook = false }) {
+  const objectToAxiosParams = (helpRequest) => ({
+    url: "/api/helprequests/post",
+    method: "POST",
+    params: {
+      requesterEmail: helpRequest.requesterEmail,
+      teamId: helpRequest.teamId,
+      tableOrBreakoutRoom: helpRequest.tableOrBreakoutRoom,
+      requestTime: helpRequest.requestTime,
+      explanation: helpRequest.explanation,
+      solved: helpRequest.solved,
+    },
+  });
+
+  const onSuccess = (helpRequest) => {
+    toast(
+      `New Help Request Created - id: ${helpRequest.id} email: ${helpRequest.requesterEmail}`,
+    );
+  };
+
+  const mutation = useBackendMutation(
+    objectToAxiosParams,
+    { onSuccess },
+    // Stryker disable next-line all : hard to set up test for caching
+    ["/api/helprequests/all"],
+  );
+
+  const { isSuccess } = mutation;
+
+  const onSubmit = async (data) => {
+    mutation.mutate(data);
+  };
+
+  if (isSuccess && !storybook) {
+    return <Navigate to="/helprequest" />;
+  }
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Create page not yet implemented</h1>
+        <h1>Create New HelpRequest</h1>
+        <HelpRequestForm submitAction={onSubmit} />
       </div>
     </BasicLayout>
   );

--- a/frontend/src/stories/pages/HelpRequest/HelpRequestCreatePage.stories.jsx
+++ b/frontend/src/stories/pages/HelpRequest/HelpRequestCreatePage.stories.jsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { http, HttpResponse } from "msw";
+
+import HelpRequestCreatePage from "main/pages/HelpRequest/HelpRequestCreatePage";
+
+export default {
+  title: "pages/HelpRequest/HelpRequestCreatePage",
+  component: HelpRequestCreatePage,
+};
+
+const Template = () => <HelpRequestCreatePage storybook={true} />;
+
+export const Default = Template.bind({});
+Default.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
+        status: 200,
+      });
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither, {
+        status: 200,
+      });
+    }),
+    http.post("/api/helprequests/post", () => {
+      return HttpResponse.json({}, { status: 200 });
+    }),
+  ],
+};

--- a/frontend/src/tests/components/HelpRequest/HelpRequestForm.test.jsx
+++ b/frontend/src/tests/components/HelpRequest/HelpRequestForm.test.jsx
@@ -1,0 +1,170 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { BrowserRouter as Router } from "react-router";
+
+import HelpRequestForm from "main/components/HelpRequest/HelpRequestForm";
+import { helpRequestFixtures } from "fixtures/helpRequestFixtures";
+
+const mockedNavigate = vi.fn();
+vi.mock("react-router", async () => {
+  const originalModule = await vi.importActual("react-router");
+  return {
+    ...originalModule,
+    useNavigate: () => mockedNavigate,
+  };
+});
+
+describe("HelpRequestForm tests", () => {
+  const expectedHeaders = [
+    "Requester Email",
+    "Team Id",
+    "Table or Breakout Room",
+    "Request Time (iso format)",
+    "Explanation",
+    "Solved",
+  ];
+  const testId = "HelpRequestForm";
+
+  test("renders correctly with no initialContents", async () => {
+    render(
+      <Router>
+        <HelpRequestForm />
+      </Router>,
+    );
+
+    expect(await screen.findByText(/Create/)).toBeInTheDocument();
+
+    expectedHeaders.forEach((headerText) => {
+      expect(screen.getByText(headerText)).toBeInTheDocument();
+    });
+  });
+
+  test("renders correctly when passing in initialContents", async () => {
+    render(
+      <Router>
+        <HelpRequestForm initialContents={helpRequestFixtures.oneHelpRequest} />
+      </Router>,
+    );
+
+    expect(await screen.findByTestId(`${testId}-id`)).toBeInTheDocument();
+    expect(screen.getByText("Id")).toBeInTheDocument();
+    expect(screen.getByTestId(`${testId}-id`)).toHaveValue("1");
+  });
+
+  test("strips trailing Z from requestTime when passed in initialContents", async () => {
+    render(
+      <Router>
+        <HelpRequestForm
+          initialContents={{
+            ...helpRequestFixtures.oneHelpRequest,
+            requestTime: "2025-10-08T17:30:00Z",
+          }}
+        />
+      </Router>,
+    );
+    const requestTimeField = await screen.findByTestId(`${testId}-requestTime`);
+    expect(requestTimeField.value.startsWith("2025-10-08T17:30")).toBe(true);
+    expect(requestTimeField.value.endsWith("Z")).toBe(false);
+  });
+
+  test("falls back to empty requestTime when initialContents has none", async () => {
+    render(
+      <Router>
+        <HelpRequestForm initialContents={{ id: 7 }} />
+      </Router>,
+    );
+    const requestTimeField = await screen.findByTestId(`${testId}-requestTime`);
+    expect(requestTimeField).toHaveValue("");
+    expect(screen.getByTestId(`${testId}-id`)).toHaveValue("7");
+  });
+
+  test("that navigate(-1) is called when Cancel is clicked", async () => {
+    render(
+      <Router>
+        <HelpRequestForm />
+      </Router>,
+    );
+    expect(await screen.findByTestId(`${testId}-cancel`)).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId(`${testId}-cancel`));
+
+    await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith(-1));
+  });
+
+  test("required field error messages on empty submit", async () => {
+    render(
+      <Router>
+        <HelpRequestForm />
+      </Router>,
+    );
+
+    fireEvent.click(await screen.findByTestId(`${testId}-submit`));
+
+    await screen.findByText(/Requester Email is required\./);
+    expect(screen.getByText(/Team Id is required\./)).toBeInTheDocument();
+    expect(
+      screen.getByText(/Table or Breakout Room is required\./),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Request Time is required\./)).toBeInTheDocument();
+    expect(screen.getByText(/Explanation is required\./)).toBeInTheDocument();
+  });
+
+  test("bad-input validation messages", async () => {
+    render(
+      <Router>
+        <HelpRequestForm />
+      </Router>,
+    );
+
+    const submitButton = await screen.findByTestId(`${testId}-submit`);
+
+    fireEvent.change(screen.getByTestId(`${testId}-requesterEmail`), {
+      target: { value: "not-an-email" },
+    });
+    fireEvent.change(screen.getByTestId(`${testId}-teamId`), {
+      target: { value: "a".repeat(31) },
+    });
+    fireEvent.change(screen.getByTestId(`${testId}-tableOrBreakoutRoom`), {
+      target: { value: "b".repeat(51) },
+    });
+    fireEvent.change(screen.getByTestId(`${testId}-explanation`), {
+      target: { value: "c".repeat(256) },
+    });
+
+    fireEvent.click(submitButton);
+
+    await screen.findByText(/Requester Email must be a valid email address\./);
+    expect(screen.getByText(/Max length 30 characters/)).toBeInTheDocument();
+    expect(screen.getByText(/Max length 50 characters/)).toBeInTheDocument();
+    expect(screen.getByText(/Max length 255 characters/)).toBeInTheDocument();
+  });
+
+  test("submitAction is called with valid input", async () => {
+    const mockSubmitAction = vi.fn();
+
+    render(
+      <Router>
+        <HelpRequestForm submitAction={mockSubmitAction} />
+      </Router>,
+    );
+
+    fireEvent.change(await screen.findByTestId(`${testId}-requesterEmail`), {
+      target: { value: "cgaucho@ucsb.edu" },
+    });
+    fireEvent.change(screen.getByTestId(`${testId}-teamId`), {
+      target: { value: "s26-5pm-3" },
+    });
+    fireEvent.change(screen.getByTestId(`${testId}-tableOrBreakoutRoom`), {
+      target: { value: "7" },
+    });
+    fireEvent.change(screen.getByTestId(`${testId}-requestTime`), {
+      target: { value: "2025-10-08T17:30" },
+    });
+    fireEvent.change(screen.getByTestId(`${testId}-explanation`), {
+      target: { value: "Need help with Swagger" },
+    });
+    fireEvent.click(screen.getByTestId(`${testId}-solved`));
+
+    fireEvent.click(screen.getByTestId(`${testId}-submit`));
+
+    await waitFor(() => expect(mockSubmitAction).toHaveBeenCalled());
+  });
+});

--- a/frontend/src/tests/pages/HelpRequest/HelpRequestCreatePage.test.jsx
+++ b/frontend/src/tests/pages/HelpRequest/HelpRequestCreatePage.test.jsx
@@ -1,18 +1,40 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import HelpRequestCreatePage from "main/pages/HelpRequest/HelpRequestCreatePage";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router";
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
-import { expect } from "vitest";
+
+const mockToast = vi.fn();
+vi.mock("react-toastify", async (importOriginal) => {
+  const originalModule = await importOriginal();
+  return {
+    ...originalModule,
+    toast: vi.fn((x) => mockToast(x)),
+  };
+});
+
+const mockNavigate = vi.fn();
+vi.mock("react-router", async (importOriginal) => {
+  const originalModule = await importOriginal();
+  return {
+    ...originalModule,
+    Navigate: vi.fn((x) => {
+      mockNavigate(x);
+      return null;
+    }),
+  };
+});
 
 describe("HelpRequestCreatePage tests", () => {
   const axiosMock = new AxiosMockAdapter(axios);
 
-  const setupUserOnly = () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
     axiosMock.reset();
     axiosMock.resetHistory();
     axiosMock
@@ -21,11 +43,36 @@ describe("HelpRequestCreatePage tests", () => {
     axiosMock
       .onGet("/api/systemInfo")
       .reply(200, systemInfoFixtures.showingNeither);
-  };
+  });
 
   const queryClient = new QueryClient();
-  test("Renders expected content", async () => {
-    setupUserOnly();
+
+  test("renders without crashing", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <HelpRequestCreatePage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Requester Email")).toBeInTheDocument();
+    });
+  });
+
+  test("on submit with valid data, POST then toast and redirect to /helprequest", async () => {
+    const saved = {
+      id: 5,
+      requesterEmail: "cgaucho@ucsb.edu",
+      teamId: "s26-5pm-3",
+      tableOrBreakoutRoom: "7",
+      requestTime: "2025-10-08T17:30:00",
+      explanation: "Need help",
+      solved: false,
+    };
+
+    axiosMock.onPost("/api/helprequests/post").reply(202, saved);
 
     render(
       <QueryClientProvider client={queryClient}>
@@ -35,9 +82,73 @@ describe("HelpRequestCreatePage tests", () => {
       </QueryClientProvider>,
     );
 
-    await screen.findByText("Create page not yet implemented");
+    await waitFor(() => {
+      expect(screen.getByLabelText("Requester Email")).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByLabelText("Requester Email"), {
+      target: { value: "cgaucho@ucsb.edu" },
+    });
+    fireEvent.change(screen.getByLabelText("Team Id"), {
+      target: { value: "s26-5pm-3" },
+    });
+    fireEvent.change(screen.getByLabelText("Table or Breakout Room"), {
+      target: { value: "7" },
+    });
+    fireEvent.change(screen.getByLabelText("Request Time (iso format)"), {
+      target: { value: "2025-10-08T17:30" },
+    });
+    fireEvent.change(screen.getByLabelText("Explanation"), {
+      target: { value: "Need help" },
+    });
+
+    fireEvent.click(screen.getByText("Create"));
+
+    await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
+
+    expect(axiosMock.history.post[0].params).toMatchObject({
+      requesterEmail: "cgaucho@ucsb.edu",
+      teamId: "s26-5pm-3",
+      tableOrBreakoutRoom: "7",
+      explanation: "Need help",
+      solved: false,
+    });
     expect(
-      screen.getByText("Create page not yet implemented"),
-    ).toBeInTheDocument();
+      axiosMock.history.post[0].params.requestTime.startsWith(
+        "2025-10-08T17:30",
+      ),
+    ).toBe(true);
+
+    expect(mockToast).toHaveBeenCalledWith(
+      "New Help Request Created - id: 5 email: cgaucho@ucsb.edu",
+    );
+    expect(mockNavigate).toHaveBeenCalledWith({ to: "/helprequest" });
+  });
+
+  test("on submit with invalid data, does not POST", async () => {
+    axiosMock.onPost("/api/helprequests/post").reply(202, { id: 1 });
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <HelpRequestCreatePage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Requester Email")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText("Create"));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Requester Email is required\./),
+      ).toBeInTheDocument();
+    });
+
+    expect(axiosMock.history.post.length).toBe(0);
+    expect(mockNavigate).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Closes #43
Swagger: POST /api/helprequests/post with query params requesterEmail, teamId, tableOrBreakoutRoom, requestTime, explanation, solved.
Manual steps: admin login → /helprequest/create → submit → redirect + GET /api/helprequests/all.
Storybook story: pages/HelpRequest/HelpRequestCreatePage (add your published URL).