### PR TITLE
IG - Edit Page for Articles Table

### DIFF
--- a/frontend/src/main/pages/Articles/ArticlesEditPage.jsx
+++ b/frontend/src/main/pages/Articles/ArticlesEditPage.jsx
@@ -1,11 +1,76 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import { useParams } from "react-router";
+import ArticlesForm from "main/components/Articles/ArticlesForm";
+import { Navigate } from "react-router";
+import { useBackend, useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
 
-export default function ArticlesEditPage() {
-  // Stryker disable all : placeholder for future implementation
+export default function ArticlesEditPage({ storybook = false }) {
+  let { id } = useParams();
+
+  const {
+    data: article,
+    _error,
+    _status,
+  } = useBackend(
+    [`/api/articles?id=${id}`],
+    {
+      // Stryker disable next-line all : GET is the default method
+      method: "GET",
+      url: "/api/articles",
+      params: {
+        id,
+      },
+    },
+  );
+
+  const objectToAxiosPutParams = (article) => ({
+    url: "/api/articles",
+    method: "PUT",
+    params: {
+      id: article.id,
+    },
+    data: {
+      title: article.title,
+      url: article.url,
+      explanation: article.explanation,
+      email: article.email,
+      localDateTime: article.localDateTime,
+    },
+  });
+
+  const onSuccess = (article) => {
+    toast(`Article Updated - id: ${article.id} title: ${article.title}`);
+  };
+
+  const mutation = useBackendMutation(
+    objectToAxiosPutParams,
+    { onSuccess },
+    // Stryker disable next-line all : cache invalidation key is hard to test directly
+    [`/api/articles?id=${id}`],
+  );
+
+  const { isSuccess } = mutation;
+
+  const onSubmit = async (data) => {
+    mutation.mutate(data);
+  };
+
+  if (isSuccess && !storybook) {
+    return <Navigate to="/articles" />;
+  }
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Edit page not yet implemented</h1>
+        <h1>Edit Article</h1>
+        {article && (
+          <ArticlesForm
+            initialContents={article}
+            submitAction={onSubmit}
+            buttonLabel="Update"
+          />
+        )}
       </div>
     </BasicLayout>
   );

--- a/frontend/src/main/pages/Articles/ArticlesEditPage.jsx
+++ b/frontend/src/main/pages/Articles/ArticlesEditPage.jsx
@@ -12,17 +12,14 @@ export default function ArticlesEditPage({ storybook = false }) {
     data: article,
     _error,
     _status,
-  } = useBackend(
-    [`/api/articles?id=${id}`],
-    {
-      // Stryker disable next-line all : GET is the default method
-      method: "GET",
-      url: "/api/articles",
-      params: {
-        id,
-      },
+  } = useBackend([`/api/articles?id=${id}`], {
+    // Stryker disable next-line all : GET is the default method
+    method: "GET",
+    url: "/api/articles",
+    params: {
+      id,
     },
-  );
+  });
 
   const objectToAxiosPutParams = (article) => ({
     url: "/api/articles",

--- a/frontend/src/stories/pages/Articles/ArticlesEditPage.stories.jsx
+++ b/frontend/src/stories/pages/Articles/ArticlesEditPage.stories.jsx
@@ -1,0 +1,38 @@
+import React from "react";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { articlesFixtures } from "fixtures/articlesFixtures";
+import { http, HttpResponse } from "msw";
+
+import ArticlesEditPage from "main/pages/Articles/ArticlesEditPage";
+
+export default {
+  title: "pages/Articles/ArticlesEditPage",
+  component: ArticlesEditPage,
+};
+
+const Template = () => <ArticlesEditPage storybook={true} />;
+
+export const Default = Template.bind({});
+Default.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
+        status: 200,
+      });
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither, {
+        status: 200,
+      });
+    }),
+    http.get("/api/articles", () => {
+      return HttpResponse.json(articlesFixtures.threeArticles[0], {
+        status: 200,
+      });
+    }),
+    http.put("/api/articles", () => {
+      return HttpResponse.json({}, { status: 200 });
+    }),
+  ],
+};

--- a/frontend/src/tests/pages/Articles/ArticlesEditPage.test.jsx
+++ b/frontend/src/tests/pages/Articles/ArticlesEditPage.test.jsx
@@ -1,47 +1,241 @@
-import { render, screen } from "@testing-library/react";
-import PlaceholderEditPage from "main/pages/Articles/ArticlesEditPage";
+import { fireEvent, render, waitFor, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router";
+import ArticlesEditPage from "main/pages/Articles/ArticlesEditPage";
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
-import { expect } from "vitest";
+
+import mockConsole from "tests/testutils/mockConsole";
+import { beforeEach, afterEach } from "vitest";
+
+const mockToast = vi.fn();
+vi.mock("react-toastify", async (importOriginal) => {
+  const originalModule = await importOriginal();
+  return {
+    ...originalModule,
+    toast: vi.fn((x) => mockToast(x)),
+  };
+});
+
+const mockNavigate = vi.fn();
+vi.mock("react-router", async (importOriginal) => {
+  const originalModule = await importOriginal();
+  return {
+    ...originalModule,
+    useParams: vi.fn(() => ({
+      id: 17,
+    })),
+    Navigate: vi.fn((x) => {
+      mockNavigate(x);
+      return null;
+    }),
+  };
+});
+
+let axiosMock;
 
 describe("ArticlesEditPage tests", () => {
-  const axiosMock = new AxiosMockAdapter(axios);
+  describe("when the backend doesn't return data", () => {
+    beforeEach(() => {
+      axiosMock = new AxiosMockAdapter(axios);
+      axiosMock
+        .onGet("/api/currentUser")
+        .reply(200, apiCurrentUserFixtures.userOnly);
+      axiosMock
+        .onGet("/api/systemInfo")
+        .reply(200, systemInfoFixtures.showingNeither);
+      axiosMock.onGet("/api/articles", { params: { id: 17 } }).timeout();
+    });
 
-  const setupUserOnly = () => {
-    axiosMock.reset();
-    axiosMock.resetHistory();
-    axiosMock
-      .onGet("/api/currentUser")
-      .reply(200, apiCurrentUserFixtures.userOnly);
-    axiosMock
-      .onGet("/api/systemInfo")
-      .reply(200, systemInfoFixtures.showingNeither);
-  };
+    afterEach(() => {
+      mockToast.mockClear();
+      mockNavigate.mockClear();
+      axiosMock.restore();
+      axiosMock.resetHistory();
+    });
 
-  const queryClient = new QueryClient();
-  test("Renders expected content", async () => {
-    // arrange
+    test("renders header but form is not present", async () => {
+      const queryClient = new QueryClient();
+      const restoreConsole = mockConsole();
 
-    setupUserOnly();
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <ArticlesEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
 
-    // act
-    render(
-      <QueryClientProvider client={queryClient}>
-        <MemoryRouter>
-          <PlaceholderEditPage />
-        </MemoryRouter>
-      </QueryClientProvider>,
-    );
+      await screen.findByText(/Welcome/);
+      await screen.findByText("Edit Article");
 
-    // assert
-    await screen.findByText("Edit page not yet implemented");
-    expect(
-      screen.getByText("Edit page not yet implemented"),
-    ).toBeInTheDocument();
+      expect(screen.queryByTestId("ArticlesForm-title")).not.toBeInTheDocument();
+
+      restoreConsole();
+    });
+  });
+
+  describe("tests where backend is working normally", () => {
+    beforeEach(() => {
+      axiosMock = new AxiosMockAdapter(axios);
+      axiosMock.reset();
+      axiosMock.resetHistory();
+
+      axiosMock
+        .onGet("/api/currentUser")
+        .reply(200, apiCurrentUserFixtures.userOnly);
+      axiosMock
+        .onGet("/api/systemInfo")
+        .reply(200, systemInfoFixtures.showingNeither);
+
+      axiosMock.onGet("/api/articles", { params: { id: 17 } }).reply(200, {
+        id: 17,
+        title: "article 1",
+        url: "https://example.com",
+        explanation: "explanation 1",
+        email: "test@ucsb.edu",
+        localDateTime: "2022-03-14T15:00",
+      });
+
+      axiosMock.onPut("/api/articles").reply(200, {
+        id: 17,
+        title: "updated article",
+        url: "https://updated.com",
+        explanation: "updated explanation",
+        email: "updated@ucsb.edu",
+        localDateTime: "2022-12-25T08:00",
+      });
+    });
+
+    afterEach(() => {
+      mockToast.mockClear();
+      mockNavigate.mockClear();
+      axiosMock.restore();
+      axiosMock.resetHistory();
+    });
+
+    test("renders without crashing", async () => {
+      const queryClient = new QueryClient();
+
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <ArticlesEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+
+      await screen.findByText(/Welcome/);
+      await screen.findByTestId("ArticlesForm-title");
+
+      expect(screen.getByTestId("ArticlesForm-title")).toBeInTheDocument();
+
+      expect(queryClient.getQueryData(["/api/articles?id=17"])).toEqual({
+        id: 17,
+        title: "article 1",
+        url: "https://example.com",
+        explanation: "explanation 1",
+        email: "test@ucsb.edu",
+        localDateTime: "2022-03-14T15:00",
+      });
+    });
+
+    test("Is populated with the data provided", async () => {
+      const queryClient = new QueryClient();
+
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <ArticlesEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+
+      await screen.findByTestId("ArticlesForm-title");
+
+      const idField = screen.getByTestId("ArticlesForm-id");
+      const titleField = screen.getByTestId("ArticlesForm-title");
+      const urlField = screen.getByTestId("ArticlesForm-url");
+      const explanationField = screen.getByTestId("ArticlesForm-explanation");
+      const emailField = screen.getByTestId("ArticlesForm-email");
+      const localDateTimeField = screen.getByTestId("ArticlesForm-localDateTime");
+      const submitButton = screen.getByTestId("ArticlesForm-submit");
+
+      expect(idField).toHaveValue("17");
+      expect(titleField).toHaveValue("article 1");
+      expect(urlField).toHaveValue("https://example.com");
+      expect(explanationField).toHaveValue("explanation 1");
+      expect(emailField).toHaveValue("test@ucsb.edu");
+      expect(localDateTimeField).toHaveValue("2022-03-14T15:00");
+      expect(submitButton).toBeInTheDocument();
+    });
+
+    test("Changes when you click Update", async () => {
+      const queryClient = new QueryClient();
+
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <ArticlesEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+
+      await screen.findByTestId("ArticlesForm-title");
+
+      const idField = screen.getByTestId("ArticlesForm-id");
+      const titleField = screen.getByTestId("ArticlesForm-title");
+      const urlField = screen.getByTestId("ArticlesForm-url");
+      const explanationField = screen.getByTestId("ArticlesForm-explanation");
+      const emailField = screen.getByTestId("ArticlesForm-email");
+      const localDateTimeField = screen.getByTestId("ArticlesForm-localDateTime");
+      const submitButton = screen.getByTestId("ArticlesForm-submit");
+
+      expect(idField).toHaveValue("17");
+
+      fireEvent.change(titleField, {
+        target: { value: "updated article" },
+      });
+      fireEvent.change(urlField, {
+        target: { value: "https://updated.com" },
+      });
+      fireEvent.change(explanationField, {
+        target: { value: "updated explanation" },
+      });
+      fireEvent.change(emailField, {
+        target: { value: "updated@ucsb.edu" },
+      });
+      fireEvent.change(localDateTimeField, {
+        target: { value: "2022-12-25T08:00" },
+      });
+
+      fireEvent.click(submitButton);
+
+      await waitFor(() => expect(mockToast).toBeCalled());
+
+      expect(mockToast).toBeCalledWith(
+        "Article Updated - id: 17 title: updated article",
+      );
+
+      expect(mockNavigate).toBeCalledWith({ to: "/articles" });
+
+      expect(axiosMock.history.put.length).toBe(1);
+      expect(axiosMock.history.put[0].params).toEqual({ id: 17 });
+
+      expect(axiosMock.history.put[0].data).toBe(
+        JSON.stringify({
+          title: "updated article",
+          url: "https://updated.com",
+          explanation: "updated explanation",
+          email: "updated@ucsb.edu",
+          localDateTime: "2022-12-25T08:00",
+        }),
+      );
+
+      expect(queryClient.getQueryState(["/api/articles?id=17"])).toBeDefined();
+    });
   });
 });

--- a/frontend/src/tests/pages/Articles/ArticlesEditPage.test.jsx
+++ b/frontend/src/tests/pages/Articles/ArticlesEditPage.test.jsx
@@ -72,7 +72,9 @@ describe("ArticlesEditPage tests", () => {
       await screen.findByText(/Welcome/);
       await screen.findByText("Edit Article");
 
-      expect(screen.queryByTestId("ArticlesForm-title")).not.toBeInTheDocument();
+      expect(
+        screen.queryByTestId("ArticlesForm-title"),
+      ).not.toBeInTheDocument();
 
       restoreConsole();
     });
@@ -161,7 +163,9 @@ describe("ArticlesEditPage tests", () => {
       const urlField = screen.getByTestId("ArticlesForm-url");
       const explanationField = screen.getByTestId("ArticlesForm-explanation");
       const emailField = screen.getByTestId("ArticlesForm-email");
-      const localDateTimeField = screen.getByTestId("ArticlesForm-localDateTime");
+      const localDateTimeField = screen.getByTestId(
+        "ArticlesForm-localDateTime",
+      );
       const submitButton = screen.getByTestId("ArticlesForm-submit");
 
       expect(idField).toHaveValue("17");
@@ -191,7 +195,9 @@ describe("ArticlesEditPage tests", () => {
       const urlField = screen.getByTestId("ArticlesForm-url");
       const explanationField = screen.getByTestId("ArticlesForm-explanation");
       const emailField = screen.getByTestId("ArticlesForm-email");
-      const localDateTimeField = screen.getByTestId("ArticlesForm-localDateTime");
+      const localDateTimeField = screen.getByTestId(
+        "ArticlesForm-localDateTime",
+      );
       const submitButton = screen.getByTestId("ArticlesForm-submit");
 
       expect(idField).toHaveValue("17");


### PR DESCRIPTION
Closes #54 
In this PR, we add edit page for Articles table with its tests.
-
There is full mutation coverage (stryker).

You can access and test the edit page on dokku via this link: https://team02-ibrahimgok01-dev.dokku-05.cs.ucsb.edu/
You can access the related storybook page via this link: https://69f3ecdac277d89602812712-gbflkdmyyb.chromatic.com/?path=/story/components-articles-articlesform--update 

Screenshot of the edit page:
<img width="1440" height="861" alt="Screenshot 2026-05-05 at 5 06 57 PM" src="https://github.com/user-attachments/assets/d4c10049-ecb2-4c02-a35d-995aa806c854" />
