### PR TITLE
Index Page for HelpRequest plus tests and stories (#44)

### DIFF
--- a/frontend/src/main/components/HelpRequest/HelpRequestTable.jsx
+++ b/frontend/src/main/components/HelpRequest/HelpRequestTable.jsx
@@ -17,7 +17,7 @@ export default function HelpRequestTable({
   const navigate = useNavigate();
 
   const editCallback = (cell) => {
-    navigate(`/helprequests/edit/${cell.row.original.id}`);
+    navigate(`/helprequest/edit/${cell.row.original.id}`);
   };
 
   // Stryker disable all : hard to test for query caching

--- a/frontend/src/main/pages/HelpRequest/HelpRequestIndexPage.jsx
+++ b/frontend/src/main/pages/HelpRequest/HelpRequestIndexPage.jsx
@@ -1,17 +1,48 @@
+import React from "react";
+import { useBackend } from "main/utils/useBackend";
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import HelpRequestTable from "main/components/HelpRequest/HelpRequestTable";
+import { useCurrentUser, hasRole } from "main/utils/useCurrentUser";
+import { Button } from "react-bootstrap";
 
 export default function HelpRequestIndexPage() {
-  // Stryker disable all : placeholder for future implementation
+  const currentUser = useCurrentUser();
+
+  const {
+    data: helpRequests,
+    error: _error,
+    status: _status,
+  } = useBackend(
+    // Stryker disable next-line all : don't test internal caching of React Query
+    ["/api/helprequests/all"],
+    { method: "GET", url: "/api/helprequests/all" },
+    // Stryker disable next-line all : don't test default value of empty list
+    [],
+  );
+
+  const createButton = () => {
+    if (hasRole(currentUser, "ROLE_ADMIN")) {
+      return (
+        <Button
+          variant="primary"
+          href="/helprequest/create"
+          style={{ float: "right" }}
+        >
+          Create HelpRequest
+        </Button>
+      );
+    }
+  };
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Index page not yet implemented</h1>
-        <p>
-          <a href="/helprequest/create">Create</a>
-        </p>
-        <p>
-          <a href="/helprequest/edit/1">Edit</a>
-        </p>
+        {createButton()}
+        <h1>HelpRequests</h1>
+        <HelpRequestTable
+          helpRequests={helpRequests}
+          currentUser={currentUser}
+        />
       </div>
     </BasicLayout>
   );

--- a/frontend/src/stories/pages/HelpRequest/HelpRequestIndexPage.stories.jsx
+++ b/frontend/src/stories/pages/HelpRequest/HelpRequestIndexPage.stories.jsx
@@ -1,0 +1,67 @@
+import React from "react";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { helpRequestFixtures } from "fixtures/helpRequestFixtures";
+import { http, HttpResponse } from "msw";
+import HelpRequestIndexPage from "main/pages/HelpRequest/HelpRequestIndexPage";
+
+export default {
+  title: "pages/HelpRequest/HelpRequestIndexPage",
+  component: HelpRequestIndexPage,
+};
+
+const Template = () => <HelpRequestIndexPage />;
+
+export const Empty = Template.bind({});
+Empty.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
+        status: 200,
+      });
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither, {
+        status: 200,
+      });
+    }),
+    http.get("/api/helprequests/all", () => {
+      return HttpResponse.json([], { status: 200 });
+    }),
+  ],
+};
+
+export const ThreeItemsOrdinaryUser = Template.bind({});
+ThreeItemsOrdinaryUser.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly);
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither);
+    }),
+    http.get("/api/helprequests/all", () => {
+      return HttpResponse.json(helpRequestFixtures.threeHelpRequests);
+    }),
+  ],
+};
+
+export const ThreeItemsAdminUser = Template.bind({});
+ThreeItemsAdminUser.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.adminUser);
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither);
+    }),
+    http.get("/api/helprequests/all", () => {
+      return HttpResponse.json(helpRequestFixtures.threeHelpRequests);
+    }),
+    http.delete("/api/helprequests", () => {
+      return HttpResponse.json("HelpRequest with id 1 was deleted", {
+        status: 200,
+      });
+    }),
+  ],
+};

--- a/frontend/src/tests/components/HelpRequest/HelpRequestTable.test.jsx
+++ b/frontend/src/tests/components/HelpRequest/HelpRequestTable.test.jsx
@@ -185,7 +185,7 @@ describe("HelpRequestTable tests", () => {
     fireEvent.click(editButton);
 
     await waitFor(() =>
-      expect(mockedNavigate).toHaveBeenCalledWith("/helprequests/edit/1"),
+      expect(mockedNavigate).toHaveBeenCalledWith("/helprequest/edit/1"),
     );
   });
 

--- a/frontend/src/tests/pages/HelpRequest/HelpRequestIndexPage.test.jsx
+++ b/frontend/src/tests/pages/HelpRequest/HelpRequestIndexPage.test.jsx
@@ -1,15 +1,25 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import HelpRequestIndexPage from "main/pages/HelpRequest/HelpRequestIndexPage";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router";
-
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { helpRequestFixtures } from "fixtures/helpRequestFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
 
+const mockToast = vi.fn();
+vi.mock("react-toastify", async (importOriginal) => {
+  const originalModule = await importOriginal();
+  return {
+    ...originalModule,
+    toast: vi.fn((x) => mockToast(x)),
+  };
+});
+
 describe("HelpRequestIndexPage tests", () => {
   const axiosMock = new AxiosMockAdapter(axios);
+  const testId = "HelpRequestTable";
 
   const setupUserOnly = () => {
     axiosMock.reset();
@@ -22,10 +32,21 @@ describe("HelpRequestIndexPage tests", () => {
       .reply(200, systemInfoFixtures.showingNeither);
   };
 
-  const queryClient = new QueryClient();
-  test("Renders expected content", async () => {
-    setupUserOnly();
+  const setupAdminUser = () => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.adminUser);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  };
 
+  test("renders with create button for admin user", async () => {
+    setupAdminUser();
+    axiosMock.onGet("/api/helprequests/all").reply(200, []);
+    const queryClient = new QueryClient();
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
@@ -34,12 +55,85 @@ describe("HelpRequestIndexPage tests", () => {
       </QueryClientProvider>,
     );
 
-    await screen.findByText("Index page not yet implemented");
+    await waitFor(() => {
+      expect(screen.getByText("Create HelpRequest")).toBeInTheDocument();
+    });
+    const button = screen.getByText("Create HelpRequest");
+    expect(button).toHaveAttribute("href", "/helprequest/create");
+    expect(button).toHaveAttribute("style", "float: right;");
+  });
 
+  test("renders three help requests correctly for regular user", async () => {
+    setupUserOnly();
+    axiosMock
+      .onGet("/api/helprequests/all")
+      .reply(200, helpRequestFixtures.threeHelpRequests);
+    const queryClient = new QueryClient();
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <HelpRequestIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(`${testId}-cell-row-0-col-id`),
+      ).toHaveTextContent("1");
+    });
+
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent(
+      "2",
+    );
+    expect(screen.getByTestId(`${testId}-cell-row-2-col-id`)).toHaveTextContent(
+      "3",
+    );
+
+    expect(screen.queryByText("Create HelpRequest")).not.toBeInTheDocument();
     expect(
-      screen.getByText("Index page not yet implemented"),
-    ).toBeInTheDocument();
-    expect(screen.getByText("Create")).toBeInTheDocument();
-    expect(screen.getByText("Edit")).toBeInTheDocument();
+      screen.queryByTestId(`${testId}-cell-row-0-col-Edit-button`),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId(`${testId}-cell-row-0-col-Delete-button`),
+    ).not.toBeInTheDocument();
+  });
+
+  test("delete button works for admin user", async () => {
+    setupAdminUser();
+    axiosMock
+      .onGet("/api/helprequests/all")
+      .reply(200, helpRequestFixtures.threeHelpRequests);
+    axiosMock
+      .onDelete("/api/helprequests")
+      .reply(200, "HelpRequest with id 1 was deleted");
+    const queryClient = new QueryClient();
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <HelpRequestIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(`${testId}-cell-row-0-col-id`),
+      ).toBeInTheDocument();
+    });
+
+    const deleteButton = screen.getByTestId(
+      `${testId}-cell-row-0-col-Delete-button`,
+    );
+    fireEvent.click(deleteButton);
+
+    await waitFor(() => {
+      expect(axiosMock.history.delete.length).toBe(1);
+    });
+    expect(axiosMock.history.delete[0].url).toBe("/api/helprequests");
+    expect(axiosMock.history.delete[0].params).toEqual({ id: 1 });
+    await waitFor(() => {
+      expect(mockToast).toBeCalledWith("HelpRequest with id 1 was deleted");
+    });
   });
 });

--- a/frontend/src/tests/pages/HelpRequest/HelpRequestIndexPage.test.jsx
+++ b/frontend/src/tests/pages/HelpRequest/HelpRequestIndexPage.test.jsx
@@ -7,6 +7,7 @@ import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import { helpRequestFixtures } from "fixtures/helpRequestFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
+import mockConsole from "tests/testutils/mockConsole";
 
 const mockToast = vi.fn();
 vi.mock("react-toastify", async (importOriginal) => {
@@ -97,6 +98,31 @@ describe("HelpRequestIndexPage tests", () => {
     expect(
       screen.queryByTestId(`${testId}-cell-row-0-col-Delete-button`),
     ).not.toBeInTheDocument();
+  });
+
+  test("renders empty table when help requests backend unavailable, user only", async () => {
+    setupUserOnly();
+    axiosMock.onGet("/api/helprequests/all").timeout();
+    const restoreConsole = mockConsole();
+    const queryClient = new QueryClient();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <HelpRequestIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(1);
+    });
+
+    const errorMessage = console.error.mock.calls[0][0];
+    expect(errorMessage).toMatch(
+      "Error communicating with backend via GET on /api/helprequests/all",
+    );
+    restoreConsole();
   });
 
   test("delete button works for admin user", async () => {

--- a/src/main/java/edu/ucsb/cs156/example/controllers/HelpRequestController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/HelpRequestController.java
@@ -13,6 +13,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -129,5 +130,24 @@ public class HelpRequestController extends ApiController {
     helpRequestRepository.save(helpRequest);
 
     return helpRequest;
+  }
+
+  /**
+   * Delete a help request
+   *
+   * @param id the id of the help request to delete
+   * @return a message indicating the help request was deleted
+   */
+  @Operation(summary = "Delete a help request")
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @DeleteMapping("")
+  public Object deleteHelpRequest(@Parameter(name = "id") @RequestParam Long id) {
+    HelpRequest helpRequest =
+        helpRequestRepository
+            .findById(id)
+            .orElseThrow(() -> new EntityNotFoundException(HelpRequest.class, id));
+
+    helpRequestRepository.delete(helpRequest);
+    return genericMessage("HelpRequest with id %s deleted".formatted(id));
   }
 }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/HelpRequestControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/HelpRequestControllerTests.java
@@ -88,6 +88,23 @@ public class HelpRequestControllerTests extends ControllerTestCase {
         .andExpect(status().is(403));
   }
 
+  // Authorization tests for DELETE /api/helprequests
+
+  @Test
+  public void logged_out_users_cannot_delete_helprequest() throws Exception {
+    mockMvc
+        .perform(delete("/api/helprequests").param("id", "15").with(csrf()))
+        .andExpect(status().is(403));
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void logged_in_regular_users_cannot_delete_helprequest() throws Exception {
+    mockMvc
+        .perform(delete("/api/helprequests").param("id", "15").with(csrf()))
+        .andExpect(status().is(403));
+  }
+
   // Tests with mocks for database actions
 
   @WithMockUser(roles = {"USER"})
@@ -302,5 +319,55 @@ public class HelpRequestControllerTests extends ControllerTestCase {
     verify(helpRequestRepository, times(1)).findById(67L);
     Map<String, Object> json = responseToJson(response);
     assertEquals("HelpRequest with id 67 not found", json.get("message"));
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void admin_can_delete_a_helprequest() throws Exception {
+
+    LocalDateTime rt = LocalDateTime.parse("2022-04-20T17:35:00");
+
+    HelpRequest helpRequest =
+        HelpRequest.builder()
+            .id(15L)
+            .requesterEmail("cgaucho@ucsb.edu")
+            .teamId("s22-5pm-3")
+            .tableOrBreakoutRoom("7")
+            .requestTime(rt)
+            .explanation("Need help with Swagger-ui")
+            .solved(true)
+            .build();
+
+    when(helpRequestRepository.findById(eq(15L))).thenReturn(Optional.of(helpRequest));
+
+    MvcResult response =
+        mockMvc
+            .perform(delete("/api/helprequests").param("id", "15").with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    verify(helpRequestRepository, times(1)).findById(15L);
+    verify(helpRequestRepository, times(1)).delete(helpRequest);
+
+    Map<String, Object> json = responseToJson(response);
+    assertEquals("HelpRequest with id 15 deleted", json.get("message"));
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void admin_tries_to_delete_non_existent_helprequest_and_gets_right_error_message()
+      throws Exception {
+
+    when(helpRequestRepository.findById(eq(15L))).thenReturn(Optional.empty());
+
+    MvcResult response =
+        mockMvc
+            .perform(delete("/api/helprequests").param("id", "15").with(csrf()))
+            .andExpect(status().isNotFound())
+            .andReturn();
+
+    verify(helpRequestRepository, times(1)).findById(15L);
+    Map<String, Object> json = responseToJson(response);
+    assertEquals("HelpRequest with id 15 not found", json.get("message"));
   }
 }


### PR DESCRIPTION
Closes #44
Endpoints: GET /api/helprequests/all, DELETE /api/helprequests?id={id} (admin), plus existing create/update/get as documented in Swagger
Manual checks:
Log in as normal user → /helprequest shows table, no Create / Edit / Delete
Log in as admin → Create, per-row Edit (/helprequest/edit/:id), Delete; after delete, row disappears after refetch

<img width="1487" height="258" alt="Screenshot 2026-05-05 at 5 34 52 PM" src="https://github.com/user-attachments/assets/28abc9fc-b816-4982-a8e8-94a508affd16" />
