### PR TITLE
Fixed Delete button for MenuItemReview

### DIFF
--- a/frontend/src/main/components/MenuItemReviews/MenuItemReviewTable.jsx
+++ b/frontend/src/main/components/MenuItemReviews/MenuItemReviewTable.jsx
@@ -25,7 +25,7 @@ export default function MenuItemReviewTable({
   const deleteMutation = useBackendMutation(
     cellToAxiosParamsDelete,
     { onSuccess: onDeleteSuccess },
-    ["/api/menuItemReviews/all"],
+    ["/api/menuitemreview/all"],
   );
   // Stryker restore all
 

--- a/frontend/src/main/utils/menuItemReviewUtils.js
+++ b/frontend/src/main/utils/menuItemReviewUtils.js
@@ -7,7 +7,7 @@ export function onDeleteSuccess(message) {
 
 export function cellToAxiosParamsDelete(cell) {
   return {
-    url: "/api/menuItemReviews",
+    url: "/api/menuitemreview",
     method: "DELETE",
     params: {
       id: cell.row.original.id,

--- a/frontend/src/tests/pages/MenuItemReviews/MenuItemReviewIndexPage.test.jsx
+++ b/frontend/src/tests/pages/MenuItemReviews/MenuItemReviewIndexPage.test.jsx
@@ -161,7 +161,7 @@ describe("MenuItemReviewIndexPage tests", () => {
       .onGet("/api/menuitemreview/all")
       .reply(200, menuItemReviewFixtures.threeReviews);
     axiosMock
-      .onDelete("/api/menuItemReviews")
+      .onDelete("/api/menuitemreview")
       .reply(200, "MenuItemReview with id 1 was deleted");
 
     render(
@@ -196,8 +196,8 @@ describe("MenuItemReviewIndexPage tests", () => {
     await waitFor(() => {
       expect(axiosMock.history.delete.length).toBe(1);
     });
-    expect(axiosMock.history.delete[0].url).toBe("/api/menuItemReviews");
-    expect(axiosMock.history.delete[0].url).toBe("/api/menuItemReviews");
+    expect(axiosMock.history.delete[0].url).toBe("/api/menuitemreview");
+    expect(axiosMock.history.delete[0].url).toBe("/api/menuitemreview");
     expect(axiosMock.history.delete[0].params).toEqual({ id: 1 });
   });
 });

--- a/frontend/src/tests/utils/MenuItemReviewUtils.test.jsx
+++ b/frontend/src/tests/utils/MenuItemReviewUtils.test.jsx
@@ -41,7 +41,7 @@ describe("MenuItemReviewUtils", () => {
 
       // assert
       expect(result).toEqual({
-        url: "/api/menuItemReviews",
+        url: "/api/menuitemreview",
         method: "DELETE",
         params: { id: 17 },
       });


### PR DESCRIPTION
This PR fixes a bug where the delete button did not successfully delete MenuItemReview objects. 

You can confirm this works by logging into this dokku instance: https://team02-elissaalawi-dev.dokku-05.cs.ucsb.edu/

Then you can create and delete an item.

It passed all tests and had full mutation coverage.